### PR TITLE
feat: add image_proc to offline mode for rectification

### DIFF
--- a/src/drs_launch/launch/component/drs_camera.launch.xml
+++ b/src/drs_launch/launch/component/drs_camera.launch.xml
@@ -44,6 +44,11 @@
         <remap from="in/compressed" to="image_raw/compressed"/>
         <remap from="out" to="image_raw"/>
       </node>
+      <node pkg="image_proc" exec="image_proc">
+        <remap from="image" to="image_raw"/>
+        <remap from="image_rect" to="image_rect_color"/>
+        <remap from="image_rect/compressed" to="image_rect_color/compressed"/>
+      </node>
     </group>
   </group>
 

--- a/src/drs_launch/launch/component/drs_camera.launch.xml
+++ b/src/drs_launch/launch/component/drs_camera.launch.xml
@@ -42,10 +42,10 @@
       <!-- User may need to overrride QoS when playing rosbag -->
       <node pkg="image_transport" exec="republish" args="compressed">
         <remap from="in/compressed" to="image_raw/compressed"/>
-        <remap from="out" to="image_raw"/>
+        <remap from="out" to="image_raw_decompressed"/>
       </node>
       <node pkg="image_proc" exec="image_proc">
-        <remap from="image" to="image_raw"/>
+        <remap from="image" to="image_raw_decompressed"/>
         <remap from="image_rect" to="image_rect_color"/>
         <remap from="image_rect/compressed" to="image_rect_color/compressed"/>
       </node>

--- a/src/drs_launch/launch/component/drs_camera.launch.xml
+++ b/src/drs_launch/launch/component/drs_camera.launch.xml
@@ -39,7 +39,7 @@
 
     <group unless="$(var live_sensor)"> <!-- Boot decompressor for offline mode -->
       <!-- XXX: The following node only accepts RELIABLE QoS as subscribed topic -->
-      <!-- User may need to overrride QoS when playing rosbag -->
+      <!-- User may need to override QoS when playing rosbag -->
       <node pkg="image_transport" exec="republish" args="compressed">
         <remap from="in/compressed" to="image_raw/compressed"/>
         <remap from="out" to="image_raw_decompressed"/>


### PR DESCRIPTION
This pull request includes an update to the `drs_camera.launch.xml` file to add a new node for image processing.

* [`src/drs_launch/launch/component/drs_camera.launch.xml`](diffhunk://#diff-a50b35b02117f939657d8d1c31e358411877df0d05998019fe910dc7e43d66b7R47-R51): Added a new `image_proc` node with remappings for `image`, `image_rect`, and `image_rect/compressed`.