### PR TITLE
feat(ansible): add a role to install utility tools

### DIFF
--- a/ansible/roles/install_utilities/tasks/main.yaml
+++ b/ansible/roles/install_utilities/tasks/main.yaml
@@ -1,0 +1,11 @@
+- name: Install utility packages via apt
+  ansible.builtin.apt:
+    name:
+      - nmon
+      - vnstat
+      - tmux
+      - tcpdump
+      - ethtool
+      - v4l-utils
+    update_cache: true
+  become: true

--- a/ansible/setup-drs.yaml
+++ b/ansible/setup-drs.yaml
@@ -85,6 +85,7 @@
     - role: ssh_key_gen
       when: drs_ecu_id == '0'
     - role: visudo_for_no_password
+    - role: install_utilities
     - role: netplan  # This role should be come at the very last of roles
 
   environment:


### PR DESCRIPTION
This PR adds a new role to install utility tools in Anvil.
The installed packages are as follows:
- nmon
- vnstat
- tmux
- tcpdump
- ethtool
- v4l-utils