### PR TITLE
fix: remove --partial option

### DIFF
--- a/ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2
+++ b/ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2
@@ -43,7 +43,7 @@ done
 # check if NAS is mounted
 if mount | grep -q $DEST_DIR; then
     echo "NAS is mounted. Start copying."
-    nice -n 19 rsync -au --partial --bwlimit=250000 --remove-source-files $SOURCE_DIR $DEST_DIR --exclude lost+found/
+    nice -n 19 rsync -au --bwlimit=250000 --remove-source-files $SOURCE_DIR $DEST_DIR --exclude lost+found/
 else
     echo "Error: NAS is not mounted."
     exit 1


### PR DESCRIPTION
This pull request includes a minor change to the `ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2` file. The change involves removing the `--partial` option from the `rsync` command used to copy files from the source directory to the destination directory.

* [`ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2`](diffhunk://#diff-e1046c3ff5495b197161813cd6e8a2fa81a8ed868ed4d6df9139bde192fe3705L46-R46): Removed the `--partial` option from the `rsync` command to ensure files are fully copied or not copied at all.