### PR TITLE
feat(ansible): switch ptpd client option according to the ECU ID

### DIFF
--- a/ansible/roles/ptpd_client/tasks/main.yaml
+++ b/ansible/roles/ptpd_client/tasks/main.yaml
@@ -6,9 +6,9 @@
   become: true
 
 - name: Copy service template file
-  ansible.builtin.copy:
-    src: ptpd_slave@.service
-    dest: /etc/systemd/system/
+  ansible.builtin.template:
+    src: ptpd_slave@.service.jinja2
+    dest: /etc/systemd/system/ptpd_slave@.service
   become: true
 
 - name: Install ptpd client service file

--- a/ansible/roles/ptpd_client/templates/ptpd_slave@.service.jinja2
+++ b/ansible/roles/ptpd_client/templates/ptpd_slave@.service.jinja2
@@ -1,3 +1,4 @@
+#jinja2: trim_blocks: False
 [Unit]
 Description=Precision Time Protocol (PTP) service
 After=network-online.target
@@ -6,7 +7,7 @@ Requires=network-online.target
 [Service]
 Type=simple
 # -s: --salveonly, -C: --foreground, -V: --verbose, -L: --ignore-lock
-ExecStart=/usr/sbin/ptpd -i %i --slaveonly --foreground --verbose --ignore-lock --ptpengine:require_utc_offset_valid=y
+ExecStart=/usr/sbin/ptpd -i %i --slaveonly --foreground --verbose --ignore-lock {% if drs_ecu_id is defined and drs_ecu_id == '1' %} --ptpengine:require_utc_offset_valid=y {% endif %}
 ExecStop=/usr/bin/pkill -f ptpd
 Restart=always
 # RestartSec=5


### PR DESCRIPTION
This PR switches PTPd client option according to ECU ID.
Because ECU ID should have `0` or `1`, ECU ID that INS will be connected is `1`

I confirmed this role works as intended inside a docker container according to the value of `drs_ecu_id`