### PR TITLE
feat: change the package branch to enable LDC=OFF function

### DIFF
--- a/autoware.repos
+++ b/autoware.repos
@@ -58,4 +58,4 @@ repositories:
   c2_readout_delay_setter:
     type: git
     url: git@github.com:tier4/c2_readout_delay_setter.git
-    version: main
+    version: feat/drs


### PR DESCRIPTION
This PR changes the branch for `c2_readout_delay_setter` so that LDC configuration is surely applied to the actual camera behavior

Related Link:
- https://github.com/tier4/c2_readout_delay_setter/tree/feat/drs