### PR TITLE
feat: switch NAS IP address according to ECU ID

### DIFF
--- a/ansible/roles/auto_storage_mount/tasks/main.yaml
+++ b/ansible/roles/auto_storage_mount/tasks/main.yaml
@@ -10,9 +10,15 @@
     path: "{{ record_root_directory }}"
     state: directory
 
+- name: Set NAS IP address according to the drs_ecu_id
+  ansible.builtin.set_fact:
+    NAS_ip_address: "{{ '192.168.10.' ~ (final_octet | int) }}"
+  vars:
+    final_octet: "{{ 100 if drs_ecu_id == '0' else 101 }}"
+
 - name: Configure auto mount NAS
   ansible.posix.mount:
-    src: 192.168.10.100:/data
+    src: "{{ NAS_ip_address }}:/data"
     path: "{{ record_root_directory }}"
     fstype: nfs
     opts: v4.1,user,rw,x-systemd.automount,x-systemd.requires=network-online.target


### PR DESCRIPTION
Due to the configuration change of the NAS compared with the one used when this role was created, this PR sets the proper IP address according to the ECU ID.

I tested the modification as follows:
```shell
# run a docker container based on Ubuntu 20.04 named `ansible_test:20.04`
docker run --rm -it --privileged -v {DRS_DIR}/ansible:/ansible --name tess ansible_test:20.04 /bin/bash

# In the docker contianer
cd /ansible

# Run the role with ECU#0 configuration
ansible localhost -m include_role -a name=./roles/auto_storage_mount -e drs_ecu_id=0 -e record_root_directory=/tmp
cp /etc/fstab /tmp/fstab.ecu0

# Run the role again with ECU#1 configuration
ansible localhost -m include_role -a name=./roles/auto_storage_mount -e drs_ecu_id=1 -e record_root_directory=/tmp
cp /etc/fstab /tmp/fstab.ecu1

# Compare the result
diff -u /tmp/fstab.ecu0 /tmp/fstab.ecu1
```
The outputs show that IP addresses for the NAS are selected properly according to the ECU ID
```diff
--- /tmp/fstab.ecu0     2025-01-20 14:09:46.276521966 +0900
+++ /tmp/fstab.ecu1     2025-01-20 14:10:02.919737200 +0900
@@ -1,2 +1,2 @@
 # UNCONFIGURED FSTAB FOR BASE SYSTEM
-192.168.10.100:/data /tmp nfs v4.1,user,rw,x-systemd.automount,x-systemd.requires=network-online.target 0 0
+192.168.10.101:/data /tmp nfs v4.1,user,rw,x-systemd.automount,x-systemd.requires=network-online.target 0 0
```

