### PR TITLE
feat: set hostname according to the ECU ID

### DIFF
--- a/ansible/roles/set_hostname/tasks/main.yaml
+++ b/ansible/roles/set_hostname/tasks/main.yaml
@@ -1,4 +1,4 @@
 - name: name hostname according to the drs_ecu_id value
   ansible.builtin.hostname:
-    name: "Anvil{{ ( drs_ecu_id | int) + 1 }}"
+    name: "anvil{{ ( drs_ecu_id | int) + 1 }}"
   become: true

--- a/ansible/roles/set_hostname/tasks/main.yaml
+++ b/ansible/roles/set_hostname/tasks/main.yaml
@@ -1,0 +1,4 @@
+- name: name hostname according to the drs_ecu_id value
+  ansible.builtin.hostname:
+    name: "Anvil{{ ( drs_ecu_id | int) + 1 }}"
+  become: true

--- a/ansible/setup-drs.yaml
+++ b/ansible/setup-drs.yaml
@@ -86,6 +86,7 @@
       when: drs_ecu_id == '0'
     - role: visudo_for_no_password
     - role: install_utilities
+    - role: set_hostname
     - role: netplan  # This role should be come at the very last of roles
 
   environment:


### PR DESCRIPTION
This PR adds a role to set the hostname to distinguish each ECU easily.

The modification was tested as follows:
```shell
# run a docker container based on Ubuntu 20.04 named `ansible_test:20.04`
docker run --rm -it --privileged -v {DRS_DIR}/ansible:/ansible --name tess ansible_test:20.04 /bin/bash

# In the docker container
cd /ansible

# Run the role with ECU#0 configuration
ansible localhost -m include_role -a name=roles/set_hostname -e drs_ecu_id=0
cat /etc/hostname 
# output: Anvil1

# Run the role again with ECU#1 configuration
ansible localhost -m include_role -a name=roles/set_hostname -e drs_ecu_id=1
cat /etc/hostname
# output: Anvil2
```

I confirmed that `/etc/hostname` was modified as intended according to the ECU ID