### PR TITLE
feat: transparent background to make pressed effect easy to see

### DIFF
--- a/src/simple_frontend/simple_frontend/software_switch_monitor.py
+++ b/src/simple_frontend/simple_frontend/software_switch_monitor.py
@@ -102,7 +102,7 @@ class SoftwareSwitch(QPushButton):
     def update_icon(self):
         size = QSize(128, 128)
         pixmap = QPixmap(size)
-        pixmap.fill(0)
+        pixmap.fill(QtCore.Qt.transparent)
         painter = QPainter(pixmap)
         self.svg_renderer.render(painter)
         painter.end()


### PR DESCRIPTION
This PR updates `software_switch_monitor` so that users can easily recognize whether the software button is pressed.

This PR behavior was tested by: `ros2 run simple_frontend software_switch_monitor`

- When released: 
![image](https://github.com/user-attachments/assets/f803e357-7869-4024-9254-cf7586cf19dd)

- When pressed: 
![image](https://github.com/user-attachments/assets/a7b090bf-2d4b-40a0-81d6-6866efb99f50)
