### PR TITLE
add option to publish static_tf

### DIFF
--- a/src/drs_launch/launch/component/tf_publisher.launch.py
+++ b/src/drs_launch/launch/component/tf_publisher.launch.py
@@ -61,6 +61,7 @@ def launch_setup(context, *args, **kwargs):
     target_frame = LaunchConfiguration('target_frame').perform(context)
     publish_camera_optical_link = LaunchConfiguration('publish_camera_optical_link')
     interval_sec = LaunchConfiguration('broadcast_interval_sec').perform(context)
+    publish_static_tf = LaunchConfiguration('publish_static_tf')
 
     launch_config_to_bool = lambda conf: bool(strtobool(conf.perform(context)))
 
@@ -87,12 +88,19 @@ def launch_setup(context, *args, **kwargs):
     else:
         camera_id = ''
 
+    if launch_config_to_bool(publish_static_tf):
+        package_name = 'tf2_ros'
+        node_name = 'static_transform_publisher'
+    else:
+        package_name = 'periodic_transform_publisher'
+        node_name = 'periodic_transform_publisher'
+
     return [
         Node(
             # name=f'lidar_camera_tf_publisher{camera_id}',
             # periodic_transform_publisher assigns unique node name with random postfix
-            package='periodic_transform_publisher',
-            executable='periodic_transform_publisher',
+            package=package_name,
+            executable=node_name,
             arguments=[
                 '--x', str(tf_data['transform']['translation']['x']),
                 '--y', str(tf_data['transform']['translation']['y']),
@@ -109,8 +117,8 @@ def launch_setup(context, *args, **kwargs):
             }]),
         Node(
             name=f'periodic_camera_optical_link_publisher{camera_id}',
-            package='periodic_transform_publisher',
-            executable='periodic_transform_publisher',
+            package=package_name,
+            executable=node_name,
             arguments=[
                 '--x', '0.0',
                 '--y', '0.0',
@@ -136,6 +144,7 @@ def generate_launch_description():
             DeclareLaunchArgument("target_frame", default_value=''),
             DeclareLaunchArgument("publish_camera_optical_link", default_value='True'),
             DeclareLaunchArgument("broadcast_interval_sec", default_value='1.0'),
+            DeclareLaunchArgument("publish_static_tf", default_value='False'),
             OpaqueFunction(function=launch_setup)
         ]
     )

--- a/src/drs_launch/launch/drs_offline.launch.xml
+++ b/src/drs_launch/launch/drs_offline.launch.xml
@@ -12,6 +12,7 @@
   <arg name="has_front4d" default="False"
        description="Should be True when a front-mounted 4D LiDAR is present"/>
   <arg name="publish_tf" default="True"/>
+  <arg name="publish_static_tf" default="False" description="If true, /tf_static will be published. If false, /tf will be published periodically."/>
 
   <let name="param_root_dir" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
 
@@ -139,6 +140,7 @@
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/base_link_to_drs_base_link.yaml"/>
         <arg name="publish_camera_optical_link" value="False"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
@@ -146,6 +148,7 @@
         <arg name="tf_file_path" value="$(var param_root_dir)/drs_base_link_to_lidars.yaml"/>
         <arg name="target_frame" value="lidar_front"/>
         <arg name="publish_camera_optical_link" value="False"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
@@ -153,6 +156,7 @@
         <arg name="tf_file_path" value="$(var param_root_dir)/drs_base_link_to_lidars.yaml"/>
         <arg name="target_frame" value="lidar_left"/>
         <arg name="publish_camera_optical_link" value="False"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
@@ -160,6 +164,7 @@
         <arg name="tf_file_path" value="$(var param_root_dir)/drs_base_link_to_lidars.yaml"/>
         <arg name="target_frame" value="lidar_right"/>
         <arg name="publish_camera_optical_link" value="False"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
@@ -167,46 +172,55 @@
         <arg name="tf_file_path" value="$(var param_root_dir)/drs_base_link_to_lidars.yaml"/>
         <arg name="target_frame" value="lidar_rear"/>
         <arg name="publish_camera_optical_link" value="False"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/camera0/camera0_calibration_results.yaml"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/camera1/camera1_calibration_results.yaml"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/camera2/camera2_calibration_results.yaml"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/camera3/camera3_calibration_results.yaml"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/camera4/camera4_calibration_results.yaml"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/camera5/camera5_calibration_results.yaml"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/camera6/camera6_calibration_results.yaml"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/tf_publisher.launch.py">
         <arg name="tf_file_path" value="$(var param_root_dir)/camera7/camera7_calibration_results.yaml"/>
+        <arg name="publish_static_tf" value="$(var publish_static_tf)"/>
       </include>
     </group>
   </group>


### PR DESCRIPTION
This pull request introduces a new feature to allow the publication of static transforms in addition to periodic transforms in the `tf_publisher` component. 
The changes include adding a new launch configuration parameter and modifying the logic to use either `static_transform_publisher` or `periodic_transform_publisher` based on this parameter.

Key changes:

* Added new launch configuration parameter `publish_static_tf` to `tf_publisher.launch.py` and `drs_offline.launch.xml`:
  * [`src/drs_launch/launch/component/tf_publisher.launch.py`](diffhunk://#diff-0539bef15bfe9f7f52d9a4c1a34c4c5cc2d11e671a1e50fe469531f6193a1440R64): Added `publish_static_tf` launch configuration and modified the `launch_setup` function to use this parameter to determine the appropriate transform publisher. [[1]](diffhunk://#diff-0539bef15bfe9f7f52d9a4c1a34c4c5cc2d11e671a1e50fe469531f6193a1440R64) [[2]](diffhunk://#diff-0539bef15bfe9f7f52d9a4c1a34c4c5cc2d11e671a1e50fe469531f6193a1440R91-R103) [[3]](diffhunk://#diff-0539bef15bfe9f7f52d9a4c1a34c4c5cc2d11e671a1e50fe469531f6193a1440L112-R121) [[4]](diffhunk://#diff-0539bef15bfe9f7f52d9a4c1a34c4c5cc2d11e671a1e50fe469531f6193a1440R147)
  * [`src/drs_launch/launch/drs_offline.launch.xml`](diffhunk://#diff-6e714f59afbdd7e7533b3677b1516a56c7206f106d28a1654c5aa5815b515a49R15): Added `publish_static_tf` argument and passed it to multiple instances of `tf_publisher.launch.py`. [[1]](diffhunk://#diff-6e714f59afbdd7e7533b3677b1516a56c7206f106d28a1654c5aa5815b515a49R15) [[2]](diffhunk://#diff-6e714f59afbdd7e7533b3677b1516a56c7206f106d28a1654c5aa5815b515a49R143-R223)