### PR TITLE
feat: add role to add user to the specific group

### DIFF
--- a/ansible/roles/add_user_to_group/tasks/main.yaml
+++ b/ansible/roles/add_user_to_group/tasks/main.yaml
@@ -1,0 +1,12 @@
+- name: Ensure target group exists
+  ansible.builtin.group:
+    name: "{{ target_group }}"
+    state: present
+  become: true
+
+- name: Add user to target group
+  ansible.builtin.user:
+    name: "{{ drs_user_name }}"
+    groups: "{{ target_group }}"
+    append: true
+  become: true

--- a/ansible/setup-drs.yaml
+++ b/ansible/setup-drs.yaml
@@ -56,6 +56,9 @@
     - role: auto_storage_mount
     - role: set_local_multicast
     - role: cgroups
+    - role: add_user_to_group
+      vars:
+        target_group: gpio
     - role: can_network_setting
       when: drs_ecu_id == '0'
     - role: enable_auto_login


### PR DESCRIPTION
This PR adds a role to add DRS user to specified groups, especially `gpio` group.

This PR was tested as follows:
```shell
# The following commands were executed in a docker container to imitate the Ubuntu 20.04 environment

# check the groups the user (named `root` in this container) belongs to
$ id $(whoami)
uid=0(root) gid=0(root) groups=0(root)

# execute the role
ansible localhost -m include_role -a name=./ansible/roles/add_user_to_group -e drs_user_name=$(whoami) -e target_group=gpio

# check the groups again
$ id $(whoami)
uid=0(root) gid=0(root) groups=0(root),1000(gpio)
```
The user was successfully added to the `gpio` group.