### PR TITLE
fix: add image_proc as an execution dependency in package.xml

### DIFF
--- a/src/drs_launch/package.xml
+++ b/src/drs_launch/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>individual_params</exec_depend>
+  <exec_depend>image_proc</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>nebula_ros</exec_depend>
   <exec_depend>oxts</exec_depend>


### PR DESCRIPTION
This pull request includes a small change to the `src/drs_launch/package.xml` file. The change adds a new dependency for `image_proc`.

* [`src/drs_launch/package.xml`](diffhunk://#diff-26f5342ef2621c44c88cef165882e6808a2075a37952a87081bc3fc4a6f7bd9dR13): Added `image_proc` as an execution dependency.