### PR TITLE
change bwlimit from 250000 to 200000 to prevent recording drop

### DIFF
--- a/ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2
+++ b/ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2
@@ -43,7 +43,7 @@ done
 # check if NAS is mounted
 if mount | grep -q $DEST_DIR; then
     echo "NAS is mounted. Start copying."
-    nice -n 19 rsync -au --bwlimit=250000 --remove-source-files $SOURCE_DIR $DEST_DIR --exclude lost+found/
+    nice -n 19 rsync -au --bwlimit=200000 --remove-source-files $SOURCE_DIR $DEST_DIR --exclude lost+found/
 else
     echo "Error: NAS is not mounted."
     exit 1


### PR DESCRIPTION
This pull request includes a small change to the `ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2` file. The change modifies the bandwidth limit for the `rsync` command from 250000 to 200000.

Change details:

* [`ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2`](diffhunk://#diff-e1046c3ff5495b197161813cd6e8a2fa81a8ed868ed4d6df9139bde192fe3705L46-R46): Adjusted the `--bwlimit` parameter in the `rsync` command to 200000.