### PR TITLE
feat(pointcloud_concatenate): suppress transform error

### DIFF
--- a/src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp
+++ b/src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp
@@ -324,6 +324,10 @@ void PointCloudOffsetConcatenationComponent::cloud_callback(
   }
   sensor_msgs::msg::PointCloud2::SharedPtr transformed_in_cloud_ptr(new sensor_msgs::msg::PointCloud2());
   transformPointCloud(input, transformed_in_cloud_ptr);
+  if (transformed_in_cloud_ptr->width == 0) {
+    RCLCPP_WARN(this->get_logger(), "Received an empty pointcloud message from topic: %s", topic.c_str());
+    return;
+  }
   convertToXYZIICloud(transformed_in_cloud_ptr, xyzii_input_ptr, static_cast<uint8_t>(topic_index));
 
   auto points_stamp_msec = input_ptr->header.stamp.sec * 1e3 + input_ptr->header.stamp.nanosec / 1e6;


### PR DESCRIPTION
This pull request introduces a new check to handle empty point cloud messages in the `cloud_callback` function. The most important change is the addition of a conditional statement that logs a warning and returns early if an empty point cloud message is received.

Improvements to error handling:

* [`src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp`](diffhunk://#diff-2575cdc78f5dd57b716d8bfdcc4875bced025e5506e86f64150cb07a75080d88R327-R330): Added a check to log a warning and return early if the received point cloud message is empty in the `cloud_callback` function.