### PR TITLE
feat: add user to the `i2c` group as well as the `gpio` group

### DIFF
--- a/ansible/roles/add_user_to_group/tasks/add_user_to_group.yaml
+++ b/ansible/roles/add_user_to_group/tasks/add_user_to_group.yaml
@@ -1,0 +1,12 @@
+- name: Ensure target group exists
+  ansible.builtin.group:
+    name: "{{ target_group }}"
+    state: present
+  become: true
+
+- name: Add user to target group
+  ansible.builtin.user:
+    name: "{{ drs_user_name }}"
+    groups: "{{ target_group }}"
+    append: true
+  become: true

--- a/ansible/roles/add_user_to_group/tasks/main.yaml
+++ b/ansible/roles/add_user_to_group/tasks/main.yaml
@@ -1,12 +1,5 @@
-- name: Ensure target group exists
-  ansible.builtin.group:
-    name: "{{ target_group }}"
-    state: present
-  become: true
-
-- name: Add user to target group
-  ansible.builtin.user:
-    name: "{{ drs_user_name }}"
-    groups: "{{ target_group }}"
-    append: true
-  become: true
+- name: add user to targe groups one by one
+  include_tasks: add_user_to_group.yaml
+  with_items: "{{ target_groups }}"
+  loop_control:
+    loop_var: target_group

--- a/ansible/setup-drs.yaml
+++ b/ansible/setup-drs.yaml
@@ -58,7 +58,9 @@
     - role: cgroups
     - role: add_user_to_group
       vars:
-        target_group: gpio
+        target_groups:
+          - gpio
+          - i2c
     - role: can_network_setting
       when: drs_ecu_id == '0'
     - role: enable_auto_login


### PR DESCRIPTION
This PR modifies the `add_user_to_group` role so that it can take multiple groups at the same time.
The modification summary is as follows:
- rename the previous `ansible/roles/add_user_to_group/tasks/main.yaml`  -> `ansible/roles/add_user_to_group/tasks/add_user_to_group.yaml`
- re-create `ansible/roles/add_user_to_group/tasks/main.yaml` so that it can take multiple groups via a variable named `target_groups`
- modify `ansible/setup-drs.yaml` to specify the target groups

This PR was tested as follows in the Ubuntu 20.04 based docker container
- comment out all roles other than add_user_to_group in ansible/setup-drs.yaml
- check the groups that the user belongs to before execution
  ```shell
  $ id root
  uid=0(root) gid=0(root) groups=0(root)
  ```
- execute playbook
  ```shell
  $ USER=root ansible-playbook ./setup-drs.yaml
  ```
- check the groups again
  ```shell
  id root
  uid=0(root) gid=0(root) groups=0(root),1000(gpio),1001(i2c)
  ```

The result shows the user was added to the `gpio` and `i2c` successfully.