### PR TITLE
fix: change command to kill process, to delete empty folders

### DIFF
--- a/ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2
+++ b/ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TIME=`date +"%Y/%m/%d_%H:%M:%S"`
+TIME=$(date +"%Y/%m/%d_%H:%M:%S")
 echo "============= start ssd_nas_sync.sh ${TIME} ==============="
 
 #backup SSD to NAS
@@ -21,34 +21,28 @@ echo "destination directory: $DEST_DIR"
 
 
 # delete empty folders
-DIRS=($(find $SOURCE_DIR -mindepth 2 -maxdepth 2 -type d))
-for DIR in "${DIRS[@]}"; do
-    DIR_SIZE=$(du -sb "$DIR" | awk '{print $1}')
-    if [ "$DIR_SIZE" -le 4100 ]; then
-        rm -r $DIR
-    fi
-done
+find "$SOURCE_DIR" -type d -empty -print -delete
 
 # check if rsync process is running
-process=`pgrep rsync | wc -l`
+process=$(pgrep rsync | wc -l)
 echo "existing process num: $process"
 while [ "$process" -gt 1 ]; do
     # kill existing rsync process
     ps aux | grep rsync | grep -v grep | awk '{ print "kill ", $2 }' | sh
     sleep 1
-    process=`pgrep rsync | wc -l`
+    process=$(pgrep rsync | wc -l)
     echo "existing process num: $process"
 done
 
 # check if NAS is mounted
-if mount | grep -q $DEST_DIR; then
+if mount | grep -q "$DEST_DIR"; then
     echo "NAS is mounted. Start copying."
-    nice -n 19 rsync -au --bwlimit=200000 --remove-source-files $SOURCE_DIR $DEST_DIR --exclude lost+found/
+    nice -n 19 rsync -au --bwlimit=200000 --remove-source-files "$SOURCE_DIR" "$DEST_DIR" --exclude lost+found/
 else
     echo "Error: NAS is not mounted."
     exit 1
 fi
 
-ENDTIME=`date +"%Y/%m/%d_%H:%M:%S"`
+ENDTIME=$(date +"%Y/%m/%d_%H:%M:%S")
 echo "============= end ssd_nas_sync.sh (${TIME}) @ ${ENDTIME} ==============="
 exit 0

--- a/ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2
+++ b/ansible/roles/rosbag_record_service/templates/ssd_nas_sync.sh.jinja2
@@ -24,20 +24,32 @@ echo "destination directory: $DEST_DIR"
 find "$SOURCE_DIR" -type d -empty -print -delete
 
 # check if rsync process is running
-process=$(pgrep rsync | wc -l)
+max_retries=5
+retry_count=0
+process=$(pgrep -x rsync | wc -l)
 echo "existing process num: $process"
-while [ "$process" -gt 1 ]; do
-    # kill existing rsync process
-    ps aux | grep rsync | grep -v grep | awk '{ print "kill ", $2 }' | sh
+while [ "$process" -gt 0 ]; do
+    echo "Stopping existing rsync processes..."
+    kill -9 $(pgrep -x rsync)
+
+    # increment retry count
+    retry_count=$((retry_count + 1))
+
+    # check if max retries reached
+    if [ "$retry_count" -ge "$max_retries" ]; then
+        echo "Max retries reached. Exiting the loop."
+        break
+    fi
+
     sleep 1
-    process=$(pgrep rsync | wc -l)
+    process=$(pgrep -x rsync | wc -l)
     echo "existing process num: $process"
 done
 
 # check if NAS is mounted
 if mount | grep -q "$DEST_DIR"; then
     echo "NAS is mounted. Start copying."
-    nice -n 19 rsync -au --bwlimit=200000 --remove-source-files "$SOURCE_DIR" "$DEST_DIR" --exclude lost+found/
+    nice -n 19 rsync -auO --bwlimit=200000 --remove-source-files "$SOURCE_DIR" "$DEST_DIR" --exclude lost+found/
 else
     echo "Error: NAS is not mounted."
     exit 1


### PR DESCRIPTION
## Description
This PR addresses two key improvements:

1. Improvement in Folder Cleanup: The command used to delete empty folders has been refined, ensuring that only truly empty directories are removed, improving the robustness of the cleanup process.
2. Enhanced Rsync Process Handling: The script now includes a retry mechanism to handle situations where rsync processes are stuck, with a maximum retry limit to prevent the script from running indefinitely. This provides better control and ensures smoother operation during the sync process.

These changes aim to optimize the efficiency and reliability of the syncing script.