### PR TITLE
fix(pointcloud_concatenate): bug in look up function

### DIFF
--- a/src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp
+++ b/src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp
@@ -345,7 +345,7 @@ void PointCloudOffsetConcatenationComponent::cloud_callback(
     }
   }
 
-  // chech if we can merge point clouds
+  // check if we can merge point clouds
   try_merge_point_clouds(points_stamp_msec + offset_map_msec_[topic]);
 }
 

--- a/src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp
+++ b/src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp
@@ -298,11 +298,11 @@ bool PointCloudOffsetConcatenationComponent::all_points_received()
 
 int PointCloudOffsetConcatenationComponent::lookup_index(const std::vector<double> & stamp_buff, const double stamp)
 {
-  constexpr int tolerance_msec = 50;
-  int min_offset_msec = tolerance_msec;
+  constexpr double tolerance_msec = 50.0;
+  double min_offset_msec = tolerance_msec;
   int min_offset_index = -1;
   for (size_t index = 0; index < stamp_buff.size(); ++index) {
-    int offset_msec = std::abs(stamp_buff[index] - stamp);
+    double offset_msec = std::abs(stamp_buff[index] - stamp);
     if (offset_msec <= tolerance_msec && offset_msec < min_offset_msec) {
       min_offset_msec = offset_msec;
       min_offset_index = index;


### PR DESCRIPTION
This pull request fix the bug in pointcloud_concatenate.
- change to the `lookup_index` method in the `PointCloudOffsetConcatenationComponent` class to improve type consistency.

Type consistency improvements:

* [`src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp`](diffhunk://#diff-2575cdc78f5dd57b716d8bfdcc4875bced025e5506e86f64150cb07a75080d88L301-R305): Changed the type of `tolerance_msec`, `min_offset_msec`, and `offset_msec` from `int` to `double` to ensure consistency in the calculations.