### PR TITLE
feat: add check_ptpd role to enable periodical ptpd status checking

### DIFF
--- a/ansible/roles/check_ptpd/defaults/main.yaml
+++ b/ansible/roles/check_ptpd/defaults/main.yaml
@@ -1,0 +1,4 @@
+check_ptpd:
+  on_boot_sec: 30sec
+  on_unit_active_sec: 5min
+  enabled_ptpd_services: ""         # should be filled in the preceding `ptpd_host` and `ptpd_client` roles

--- a/ansible/roles/check_ptpd/meta/main.yaml
+++ b/ansible/roles/check_ptpd/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - drs_env_setting

--- a/ansible/roles/check_ptpd/tasks/main.yaml
+++ b/ansible/roles/check_ptpd/tasks/main.yaml
@@ -1,0 +1,32 @@
+- name: Copy service body script
+  ansible.builtin.template:
+    src: check_ptpd.sh.jinja2
+    dest: /opt/drs/check_ptpd.sh
+  become: true
+
+- name: Copy service template files
+  block:
+    - name: Copy callee service template
+      ansible.builtin.template:
+        src: check_ptpd.service.jinja2
+        dest: /etc/systemd/system/check_ptpd.service
+    - name: Copy timer service template
+      ansible.builtin.template:
+        src: check_ptpd.timer.jinja2
+        dest: /etc/systemd/system/check_ptpd.timer
+  become: true
+
+- name: Install services
+  block:
+    - name: enable callee service
+      ansible.builtin.systemd:
+        name: check_ptpd.service
+        daemon_reload: true
+        enabled: true
+    - name: enable timer service
+      ansible.builtin.systemd:
+        name: check_ptpd.timer
+        daemon_reload: true
+        enabled: true
+  become: true
+

--- a/ansible/roles/check_ptpd/templates/check_ptpd.service.jinja2
+++ b/ansible/roles/check_ptpd/templates/check_ptpd.service.jinja2
@@ -1,0 +1,10 @@
+#jinja2: trim_blocks: False
+[Unit]
+Description=Check and restart failed PTPD services
+
+[Service]
+Type=oneshot
+ExecStart=/opt/drs/check_ptpd.sh
+
+[Install]
+WantedBy=multi-user.target network-online.target

--- a/ansible/roles/check_ptpd/templates/check_ptpd.sh.jinja2
+++ b/ansible/roles/check_ptpd/templates/check_ptpd.sh.jinja2
@@ -1,0 +1,22 @@
+#jinja2: trim_blocks: True
+#!/bin/bash
+
+# List of services to be monitored
+SERVICES=(
+{% for item in enabled_ptpd_services %}
+  "{{ item }}"
+{% endfor %}
+)
+
+LOG_FILE="/var/log/ptpd_monitor.log"
+
+# Get the current timestamp
+DATE=$(date "+%Y-%m-%d %H:%M:%S")
+
+for SERVICE in "${SERVICES[@]}"; do
+    # Check if the service has failed
+    if systemctl is-failed --quiet "$SERVICE"; then
+        echo "$DATE: $SERVICE failed. Restarting..." | tee -a "$LOG_FILE"
+        systemctl restart "$SERVICE"
+    fi
+done

--- a/ansible/roles/check_ptpd/templates/check_ptpd.timer.jinja2
+++ b/ansible/roles/check_ptpd/templates/check_ptpd.timer.jinja2
@@ -3,8 +3,8 @@
 Description=Run check_ptpd.service every 5min
 
 [Timer]
-OnBootSec="{{ check_ptpd.on_boot_sec }}"
-OnUnitActiveSec="{{ check_ptpd.on_unit_active_sec }}"
+OnBootSec={{ check_ptpd.on_boot_sec }}
+OnUnitActiveSec={{ check_ptpd.on_unit_active_sec }}
 Unit=check_ptpd.service
 
 [Install]

--- a/ansible/roles/check_ptpd/templates/check_ptpd.timer.jinja2
+++ b/ansible/roles/check_ptpd/templates/check_ptpd.timer.jinja2
@@ -1,0 +1,11 @@
+#jinja2: trim_blocks: False
+[Unit]
+Description=Run check_ptpd.service every 5min
+
+[Timer]
+OnBootSec="{{ check_ptpd.on_boot_sec }}"
+OnUnitActiveSec="{{ check_ptpd.on_unit_active_sec }}"
+Unit=check_ptpd.service
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/ptpd_client/tasks/main.yaml
+++ b/ansible/roles/ptpd_client/tasks/main.yaml
@@ -19,3 +19,8 @@
     masked: false
   become: true
   with_items: "{{ ptpd_client_interfaces }}"
+
+- name: Save service name for later use
+  set_fact:
+    enabled_ptpd_services: "{{ (enabled_ptpd_services | default([])) + ['ptpd_slave@' + item + '.service'] }}"
+  with_items: "{{ ptpd_client_interfaces }}"

--- a/ansible/roles/ptpd_host/tasks/main.yaml
+++ b/ansible/roles/ptpd_host/tasks/main.yaml
@@ -19,3 +19,8 @@
     masked: false
   become: true
   with_items: "{{ ptpd_host_interfaces }}"
+
+- name: Save service name for later use
+  set_fact:
+    enabled_ptpd_services: "{{ (enabled_ptpd_services | default([])) + ['ptpd_master@' + item + '.service'] }}"
+  with_items: "{{ ptpd_host_interfaces }}"

--- a/ansible/setup-drs.yaml
+++ b/ansible/setup-drs.yaml
@@ -92,6 +92,7 @@
     - role: visudo_for_no_password
     - role: install_utilities
     - role: set_hostname
+    - role: check_ptpd
     - role: netplan  # This role should be come at the very last of roles
 
   environment:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

This PR adds a service named `check_ptpd` to periodically check the ptpd service's liveliness.
The original strategy comes from [CoMLOpsDatasetTools](https://github.com/tier4/CoMLOpsDatasetTools/tree/main/drs_utils), and this PR does mostly porting from there

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

- https://github.com/tier4/CoMLOpsDatasetTools/tree/main/drs_utils

## Tests performed

<!-- Describe how you have tested this PR. -->

- Comment out all roles except `ptpd_host`, `ptpd_client` and `check_ptpd` in `ansible_setup-drs.yaml
- run `ansible-playbook ansible/setup-drs.yaml --ask-become-pass` 
- The contents of `/opr/drs/check_ptpd.sh` will be changed according to the ECU ID specified during the playbook execution. On my test environment, I acquired the following results for each ECU ID:
  ```shell
  # For ECU0
  #!/bin/bash

  # List of services to be monitored
  SERVICES=(
    "ptpd_master@mgbe0.service"
    "ptpd_master@eqos0.service"
    "ptpd_slave@eth0.service"
  )

  LOG_FILE="/var/log/ptpd_monitor.log"

  # Get the current timestamp
  DATE=$(date "+%Y-%m-%d %H:%M:%S")

  for SERVICE in "${SERVICES[@]}"; do
      # Check if the service has failed
      if systemctl is-failed --quiet "$SERVICE"; then
          echo "$DATE: $SERVICE failed. Restarting..." | tee -a "$LOG_FILE"
          systemctl restart "$SERVICE"
      fi
  done
  ```
  ```bash
  # For ECU1
  #!/bin/bash

  # List of services to be monitored
  SERVICES=(
    "ptpd_master@mgbe0.service"
    "ptpd_master@eqos0.service"
    "ptpd_master@eth0.service"
    "ptpd_slave@eth1.service"
  )

  LOG_FILE="/var/log/ptpd_monitor.log"

  # Get the current timestamp
  DATE=$(date "+%Y-%m-%d %H:%M:%S")

  for SERVICE in "${SERVICES[@]}"; do
      # Check if the service has failed
      if systemctl is-failed --quiet "$SERVICE"; then
          echo "$DATE: $SERVICE failed. Restarting..." | tee -a "$LOG_FILE"
          systemctl restart "$SERVICE"
      fi
  done
  ```


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

N/A

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
N/A

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
N/A