### PR TITLE
fix: update topic rate monitoring settings

### DIFF
--- a/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
+++ b/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
@@ -30,8 +30,6 @@ topics:
     min_rate: 9.0
     max_rate: 15.0
   - name: /tf_static # tf
-    min_rate: 0.1
-    max_rate: 10.0
   - name: /sensing/ins/oxts/imu
   - name: /sensing/ins/oxts/imu_bias
   - name: /sensing/ins/oxts/lever_arm

--- a/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
+++ b/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
@@ -33,26 +33,10 @@ topics:
     min_rate: 0.1
     max_rate: 10.0
   - name: /sensing/ins/oxts/imu
-    min_rate: 45.0
-    max_rate: 55.0
   - name: /sensing/ins/oxts/imu_bias
-    min_rate: 4.0
-    max_rate: 6.0
   - name: /sensing/ins/oxts/lever_arm
-    min_rate: 4.0
-    max_rate: 6.0
   - name: /sensing/ins/oxts/nav_sat_fix
-    min_rate: 9.0
-    max_rate: 12.0
   - name: /sensing/ins/oxts/nav_sat_ref
-    min_rate: 9.0
-    max_rate: 12.0
   - name: /sensing/ins/oxts/ncom
-    min_rate: 95.0
-    max_rate: 105.0
   - name: /sensing/ins/oxts/odometry
-    min_rate: 45.0
-    max_rate: 55.0
   - name: /sensing/ins/oxts/velocity
-    min_rate: 45.0
-    max_rate: 55.0


### PR DESCRIPTION
## Description
Removed min_rate and max_rate settings for topics where the configured rate was incorrect or where detailed rate monitoring is not necessary.

## Tests performed
Verified the status on the dashboard after applying the configuration:
- Confirmed status shows OK when topics are being published
- Confirmed status shows warn when no topics are published

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
