### PR TITLE
feat(pre-commit): use ansible==6.7.0 for ansible-lint

### DIFF
--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -3,3 +3,5 @@ repos:
     rev: v6.17.2
     hooks:
       - id: ansible-lint
+        additional_dependencies:
+          - 'ansible==6.7.0'


### PR DESCRIPTION
This pull request updates the pre-commit Ansible linting configuration to ensure a specific version of Ansible is used during lint checks.

Pre-commit configuration update:

* [`.pre-commit-config-ansible.yaml`](diffhunk://#diff-ae3e1e54e6540a91ad531a5c308011e7f6dd23fcb2549256579b8c1ac4e14e4dR6-R7): Added `ansible==6.7.0` as an additional dependency for the `ansible-lint` hook to guarantee compatibility and consistent linting results.
