### PR TITLE
feat(pre-commit): update ansible-lint dependencies

### DIFF
--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -3,3 +3,6 @@ repos:
     rev: v6.17.2
     hooks:
       - id: ansible-lint
+        additional_dependencies:
+          - 'ansible-core==2.17.14'
+          - 'ansible==10.7.9'

--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -4,5 +4,5 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
-          - 'ansible-core==2.17.14'
-          - 'ansible==10.7.0'
+          - ansible-core==2.17.14
+          - ansible==10.7.0

--- a/.pre-commit-config-ansible.yaml
+++ b/.pre-commit-config-ansible.yaml
@@ -5,4 +5,4 @@ repos:
       - id: ansible-lint
         additional_dependencies:
           - 'ansible-core==2.17.14'
-          - 'ansible==10.7.9'
+          - 'ansible==10.7.0'


### PR DESCRIPTION
This pull request makes a small configuration update to the `.pre-commit-config-ansible.yaml` file to specify exact versions of Ansible dependencies for linting.

* Added `additional_dependencies` to the `ansible-lint` hook to require `ansible-core==2.17.14` and `ansible==10.7.0`.
