### PR TITLE
refactor: ignore external git repositories and temporary ansible directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ log/
 
 # Jetbrains
 .idea/
+
+# External repositories
+src/bag_converter/
+src/drs-api/
+src/proto_recorder
+
+# Ansible temporary directories
+.ansible/


### PR DESCRIPTION

# Whats changed

- Added external git repositories (imported by vcs) and temporary directories created by ansible to .gitignore, to prevent git tracking.