### PR TITLE
feat: add support for Seyond LiDAR driver

### DIFF
--- a/drs.repos
+++ b/drs.repos
@@ -51,5 +51,5 @@ repositories:
   bag_converter/src/seyond_decoder/src/seyond_sdk:
     type: git
     url: https://github.com/Seyond-Inc/inno-lidar-sdk.git
-    version: 622223c6f9ec7e32326aa6a2d83f83cb6a84dfcb  # main
+    version: e7e40ca635605447dbf8d73735706aee56b13f70  # main
 

--- a/drs.repos
+++ b/drs.repos
@@ -48,3 +48,8 @@ repositories:
     type: git
     url: https://github.com/tier4/bag_converter.git
     version: 2413e30400a0845c4390af7243093ba3160ab3be  # main
+  bag_converter/src/seyond_decoder/src/seyond_sdk:
+    type: git
+    url: https://github.com/Seyond-Inc/inno-lidar-sdk.git
+    version: 622223c6f9ec7e32326aa6a2d83f83cb6a84dfcb  # main
+

--- a/drs.repos
+++ b/drs.repos
@@ -48,8 +48,3 @@ repositories:
     type: git
     url: https://github.com/tier4/bag_converter.git
     version: 2413e30400a0845c4390af7243093ba3160ab3be  # main
-  bag_converter/src/seyond_decoder/src/seyond_sdk:
-    type: git
-    url: https://github.com/Seyond-Inc/inno-lidar-sdk.git
-    version: 622223c6f9ec7e32326aa6a2d83f83cb6a84dfcb  # main
-

--- a/drs.repos
+++ b/drs.repos
@@ -15,6 +15,15 @@ repositories:
     type: git
     url: https://github.com/tier4/nebula_drs.git
     version: 7081f40b32341d8d82ef00dee20b856e4283d4e9  # aeva_seyond
+  dependencies/seyond_ros_driver:
+    type: git
+    url: git@github.com:tier4/seyond_ros_driver.git
+    version: 516db2d344105935b56c979b0c1b138e28b08434  # tier4/develop
+    recursive: true
+  dependencies/seyond_ros_driver/src/seyond_lidar_ros/src/seyond_sdk:
+    type: git
+    url: git@github.com:Seyond-Inc/inno-lidar-sdk.git
+    version: e7e40ca635605447dbf8d73735706aee56b13f70  # main
   dependencies/transport_drivers:
     type: git
     url: https://github.com/mojomex/transport_drivers

--- a/drs.repos
+++ b/drs.repos
@@ -22,7 +22,7 @@ repositories:
     recursive: true
   dependencies/seyond_ros_driver/src/seyond_lidar_ros/src/seyond_sdk:
     type: git
-    url: git@github.com:Seyond-Inc/inno-lidar-sdk.git
+    url: https://github.com/Seyond-Inc/inno-lidar-sdk.git
     version: e7e40ca635605447dbf8d73735706aee56b13f70  # main
   dependencies/transport_drivers:
     type: git

--- a/src/drs_launch/launch/component/drs_nebula.launch.xml
+++ b/src/drs_launch/launch/component/drs_nebula.launch.xml
@@ -1,0 +1,48 @@
+<launch>
+  <arg name="lidar_position"/>
+  <arg name="lidar_model"/>
+  <arg name="live_sensor"/>
+  <arg name="publish_pointcloud" default="True"/>
+  <arg name="return_mode" default="Dual"/>
+  <arg name="scan_phase" default="0.0"/>
+  <arg name="min_range" default="0.0"/>
+  <arg name="max_range" default="300.0"/>
+  <arg name="sensor_ip"/>
+  <arg name="host_ip"/>
+  <arg name="data_port" default="8010"/>
+  <arg name="ptp_profile" default="1588v2"/>
+  <arg name="ptp_transport_type" default="UDP"/>
+  <arg name="ptp_switch_type" default="TSN"/>
+  <arg name="setup_sensor" default="True"/>
+  <arg name="retry_hw" default="True"/>
+  <arg name="debug_logging" default="False"/>
+  <arg name="calibration_file_path" default=""/>
+
+
+  <group>
+    <let name="lidar_name" value="lidar_$(var lidar_position)"/>
+    <let name="debug_level" value="debug" if="$(eval $(var debug_logging))"/>
+    <let name="debug_level" value="info" unless="$(eval $(var debug_logging))"/>
+
+    <node pkg="nebula_ros" exec="seyond_ros_wrapper_node"
+      name="$(var lidar_name)" output="screen">
+      <param name="sensor_model" value="$(var lidar_model)"/>
+      <param name="return_mode" value="$(var return_mode)"/>
+      <param name="frame_id" value="$(var lidar_name)"/>
+      <param name="scan_phase" value="$(var scan_phase)"/>
+      <param name="min_range" value="$(var min_range)"/>
+      <param name="max_range" value="$(var max_range)"/>
+      <param name="sensor_ip" value="$(var sensor_ip)"/>
+      <param name="launch_hw" value="$(var live_sensor)"/>
+      <param name="publish_pointcloud" value="$(var publish_pointcloud)"/>
+      <param name="calibration_file_path" value="$(var calibration_file_path)"/>
+      <param name="host_ip" value="$(var host_ip)"/>
+      <param name="data_port" value="$(var data_port)"/>
+      <param name="setup_sensor" value="$(var setup_sensor)"/>
+      <param name="retry_hw" value="$(var retry_hw)"/>
+      <param name="ptp_profile" value="$(var ptp_profile)"/>
+      <param name="ptp_transport_type" value="$(var ptp_transport_type)"/>
+      <param name="ptp_switch_type" value="$(var ptp_switch_type)"/>
+    </node>
+  </group>
+</launch>

--- a/src/drs_launch/launch/component/drs_seyond.launch.xml
+++ b/src/drs_launch/launch/component/drs_seyond.launch.xml
@@ -1,48 +1,33 @@
 <launch>
   <arg name="lidar_position"/>
-  <arg name="lidar_model"/>
-  <arg name="live_sensor"/>
-  <arg name="publish_pointcloud" default="True"/>
-  <arg name="return_mode" default="Dual"/>
-  <arg name="scan_phase" default="0.0"/>
-  <arg name="min_range" default="0.0"/>
-  <arg name="max_range" default="300.0"/>
-  <arg name="sensor_ip"/>
-  <arg name="host_ip"/>
-  <arg name="data_port" default="8010"/>
-  <arg name="ptp_profile" default="1588v2"/>
-  <arg name="ptp_transport_type" default="UDP"/>
-  <arg name="ptp_switch_type" default="TSN"/>
-  <arg name="setup_sensor" default="True"/>
-  <arg name="retry_hw" default="True"/>
-  <arg name="debug_logging" default="False"/>
-  <arg name="calibration_file_path" default=""/>
-
+  <arg name="live_sensor" default="true" />
+  <arg name="publish_pointcloud" default="true" />
+  <arg name="lidar_name" default="lidar_$(var lidar_position)" />
+  <arg name="sensor_ip" default="172.168.1.10" />
+  <arg name="data_port" default="8010" />
+  <arg name="reflectance_mode" default="true" />
+  <arg name="multiple_return" default="1" />
+  <arg name="continue_live" default="false" />
+  <arg name="calibration_file_path" default="" />
+  <arg name="max_range" default="2000.0" />
+  <arg name="min_range" default="0.4" />
 
   <group>
-    <let name="lidar_name" value="lidar_$(var lidar_position)"/>
-    <let name="debug_level" value="debug" if="$(eval $(var debug_logging))"/>
-    <let name="debug_level" value="info" unless="$(eval $(var debug_logging))"/>
-
-    <node pkg="nebula_ros" exec="seyond_ros_wrapper_node"
-      name="$(var lidar_name)" output="screen">
-      <param name="sensor_model" value="$(var lidar_model)"/>
-      <param name="return_mode" value="$(var return_mode)"/>
-      <param name="frame_id" value="$(var lidar_name)"/>
-      <param name="scan_phase" value="$(var scan_phase)"/>
-      <param name="min_range" value="$(var min_range)"/>
-      <param name="max_range" value="$(var max_range)"/>
-      <param name="sensor_ip" value="$(var sensor_ip)"/>
-      <param name="launch_hw" value="$(var live_sensor)"/>
-      <param name="publish_pointcloud" value="$(var publish_pointcloud)"/>
-      <param name="calibration_file_path" value="$(var calibration_file_path)"/>
-      <param name="host_ip" value="$(var host_ip)"/>
-      <param name="data_port" value="$(var data_port)"/>
-      <param name="setup_sensor" value="$(var setup_sensor)"/>
-      <param name="retry_hw" value="$(var retry_hw)"/>
-      <param name="ptp_profile" value="$(var ptp_profile)"/>
-      <param name="ptp_transport_type" value="$(var ptp_transport_type)"/>
-      <param name="ptp_switch_type" value="$(var ptp_switch_type)"/>
+    <node pkg="seyond" exec="seyond_component_node" name="$(var lidar_name)" output="screen" >
+      <param name="replay_rosbag" value="$(eval 'not $(var live_sensor)')" />
+      <param name="packet_mode" value="true" />
+      <param name="publish_pointcloud" value="$(var publish_pointcloud)" />
+      <param name="frame_id" value="$(var lidar_name)" />
+      <param name="lidar_name" value="$(var lidar_name)" />
+      <param name="lidar_ip" value="$(var sensor_ip)" />
+      <param name="port" value="8010" />
+      <param name="udp_port" value="$(var data_port)" />
+      <param name="reflectance_mode" value="$(var reflectance_mode)" />
+      <param name="multiple_return" value="$(var multiple_return)" />
+      <param name="continue_live" value="$(var continue_live)" />
+      <param name="hv_table_file" value="$(var calibration_file_path)" />
+      <param name="max_range" value="$(var max_range)" />
+      <param name="min_range" value="$(var min_range)" />
     </node>
   </group>
 </launch>

--- a/src/drs_launch/launch/drs.launch.xml
+++ b/src/drs_launch/launch/drs.launch.xml
@@ -12,6 +12,8 @@
        description="Should be False when LiDAR-camera extrinsic calibration"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"
        description="Root directory for sensor parameters"/>
+  <arg name="lidar_driver_type" default="nebula"
+       description="Type of LiDAR driver to use: nebula or seyond"/>
 
   <include file="$(find-pkg-share drs_launch)/launch/drs_ecu$(var drs_ecu_id).launch.xml">
     <arg name="vehicle_id" value="$(var vehicle_id)"/>
@@ -20,6 +22,7 @@
     <arg name="has_front4d" value="$(var has_front4d)"/>
     <arg name="publish_tf" value="$(var publish_tf)"/>
     <arg name="param_root_dir" value="$(var param_root_dir)"/>
+    <arg name="lidar_driver_type" value="$(var lidar_driver_type)"/>
   </include>
 
 </launch>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -48,7 +48,7 @@
       <push-ros-namespace namespace="lidar"/>
       <group>
         <push-ros-namespace namespace="front"/>
-        <include file="$(find-pkg-share drs_launch)/launch/component/drs_seyond.launch.xml">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="front"/>
           <arg name="lidar_model" value="Falcon"/>
           <arg name="live_sensor" value="$(var live_sensor)"/>
@@ -62,7 +62,7 @@
 
       <group>
         <push-ros-namespace namespace="right"/>
-        <include file="$(find-pkg-share drs_launch)/launch/component/drs_seyond.launch.xml">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="right"/>
           <arg name="lidar_model" value="RobinW"/>
           <arg name="live_sensor" value="$(var live_sensor)"/>

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -48,7 +48,7 @@
       <push-ros-namespace namespace="lidar"/>
       <group>
         <push-ros-namespace namespace="rear"/>
-        <include file="$(find-pkg-share drs_launch)/launch/component/drs_seyond.launch.xml">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="rear"/>
           <arg name="lidar_model" value="Falcon"/>
           <arg name="live_sensor" value="$(var live_sensor)"/>
@@ -62,7 +62,7 @@
 
       <group>
         <push-ros-namespace namespace="left"/>
-        <include file="$(find-pkg-share drs_launch)/launch/component/drs_seyond.launch.xml">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="left"/>
           <arg name="lidar_model" value="RobinW"/>
           <arg name="live_sensor" value="$(var live_sensor)"/>

--- a/src/drs_launch/package.xml
+++ b/src/drs_launch/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>image_proc</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>nebula_ros</exec_depend>
+  <exec_depend>seyond</exec_depend>
   <exec_depend>oxts</exec_depend>
   <exec_depend>sensor_trigger</exec_depend>
   <exec_depend>v4l2_camera</exec_depend>


### PR DESCRIPTION
### **Description**

This pull request introduces support for the official `seyond_ros_driver` for Seyond LiDARs, adding it as an alternative to the existing `nebula_ros` driver.

To ensure backward compatibility and avoid breaking existing configurations, this new driver is **not enabled by default**. A new launch argument, `lidar_driver_type`, has been added to select the desired driver. The default value for this argument is set to `nebula`.

### **Key Changes**

* **New Launch Argument**:
    * Introduced a new `lidar_driver_type` argument in `drs.launch.xml`.
    * This argument defaults to `nebula` to maintain existing behavior.
* **Dynamic Driver Launching**:
    * The `drs_ecu0.launch.xml` and `drs_ecu1.launch.xml` files have been updated to dynamically load the component launch file based on the `lidar_driver_type` variable (e.g., `drs_$(var lidar_driver_type).launch.xml`).
* **New Dependencies**:
    * Added `tier4/seyond_ros_driver` and its dependency `Seyond-Inc/inno-lidar-sdk` to the `drs.repos` file.
    * Added `<exec_depend>seyond</exec_depend>` to the `drs_launch/package.xml` to declare the new package dependency.
* **Launch File Updates**:
    * Modified `drs_seyond.launch.xml` to launch the `seyond_component_node` from the `seyond` package instead of the previously used `seyond_ros_wrapper_node` from `nebula_ros`.
* **Dependency Fix**:
    * Updated the URL for the `inno-lidar-sdk` dependency to use `https` instead of `git@`.

### **Verification**
* Confirmed seyond LiDAR driver works correctly and can be recorded with HILS by updating `lidar_driver_type` to `seyond` and record topics.
* Seyond SDK is built within colcon build process.