### PR TITLE
fix: update ptp4l.conf to use GNSS/INS as GM

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -20,7 +20,10 @@
     "v4l2",
     "jsonfile",
     "aabbccdd",
-    "eeffgghh"
+    "eeffgghh",
+    "mgbe",
+    "eqos",
+    "jbod"
   ],
   "import": [
     "https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"

--- a/ansible/inventory/host_vars/ecu0.yaml
+++ b/ansible/inventory/host_vars/ecu0.yaml
@@ -16,7 +16,7 @@ ptp:
   slave_ports:
     - eqos0
     - enP1p1s0
-  clock_class: 52
+  clock_class: 187
   priority1: 128
   priority2: 128
 

--- a/ansible/roles/ptp/templates/ptp4l.conf.j2
+++ b/ansible/roles/ptp/templates/ptp4l.conf.j2
@@ -5,12 +5,10 @@ step_threshold          1.0
 first_step_threshold    1.0
 tx_timestamp_timeout    1000
 boundary_clock_jbod     1
-# clock_class_threshold   51
 clockClass              {{ ptp.clock_class }}
 priority1               {{ ptp.priority1 }}
 priority2               {{ ptp.priority2 }}
 utc_offset              0
-# ptp_minor_version       0
 
 time_stamping           hardware
 delay_mechanism         E2E


### PR DESCRIPTION
## Description

This pull request updates the `ptp4l` configuration to correctly use the GNSS/INS (AV200) unit as the PTP Grandmaster (GM).

The primary change involves updating the `clock_class` variable in the Ansible host variables from 52 to **187** and ensuring this value is correctly applied in the `ptp4l.conf.j2` template.

## Changes

* **`ansible/inventory/host_vars/ecub.yaml`**:
    * Changed `clock_class` from `52` to `187`.
* **`ansible/roles/ptp/templates/ptp4l.conf.j2`**:
    * Removed the unused, commented-out line `#clock_class_threshold 51`.

## ❗ Required Device Configuration

For this configuration to function correctly, the **GNSS/INS (AV200)** unit must be set up with the following configuration:

* **Firmware Version:** `240917x` (or later)
* **PTP Time Mode:** `PTP` (Set on the device side)

## ✅ Verification

The new configuration has been successfully tested and confirmed to operate correctly on the following vehicles:

* Astemo No.1 and 2
* ID No.1