### PR TITLE
refactor: update Docker image names to pkg-drs prefix

### DIFF
--- a/docker/calibration/build.sh
+++ b/docker/calibration/build.sh
@@ -9,6 +9,6 @@ cd "$(dirname "$0")/../.."
 echo "Building DRS Docker image..."
 
 # Build the image from repository root
-docker build -t tier4/drs-calibration:latest -f docker/calibration/Dockerfile .
+docker build -t tier4/pkg-drs-calibration:latest -f docker/calibration/Dockerfile .
 
-echo "Docker image built successfully: tier4/drs-calibration:latest"
+echo "Docker image built successfully: tier4/pkg-drs-calibration:latest"

--- a/docker/calibration/run.sh
+++ b/docker/calibration/run.sh
@@ -93,4 +93,4 @@ done
 # echo "Command args: ${COMMAND_ARGS[@]}"
 
 # Execute Docker command
-docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" ghcr.io/tier4/drs-calibration:latest "${COMMAND_ARGS[@]}"
+docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" ghcr.io/tier4/pkg-drs-calibration:latest "${COMMAND_ARGS[@]}"

--- a/docker/runtime/build.sh
+++ b/docker/runtime/build.sh
@@ -9,6 +9,6 @@ cd "$(dirname "$0")/../.."
 echo "Building DRS Docker image..."
 
 # Build the image from repository root
-docker build -t tier4/drs-runtime:latest -f docker/runtime/Dockerfile .
+docker build -t tier4/pkg-drs-runtime:latest -f docker/runtime/Dockerfile .
 
-echo "Docker image built successfully: tier4/drs-runtime:latest"
+echo "Docker image built successfully: tier4/pkg-drs-runtime:latest"

--- a/docker/runtime/run.sh
+++ b/docker/runtime/run.sh
@@ -93,4 +93,4 @@ done
 # echo "Command args: ${COMMAND_ARGS[@]}"
 
 # Execute Docker command
-docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" ghcr.io/tier4/drs-runtime:latest "${COMMAND_ARGS[@]}"
+docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" ghcr.io/tier4/pkg-drs-runtime:latest "${COMMAND_ARGS[@]}"


### PR DESCRIPTION
# Branch Summary: `refactor/switch-drs-package-registries` vs `develop/r36.4.0`

## Overview
This branch refactors the Docker image naming convention from `drs-*` to `pkg-drs-*` prefix for both calibration and runtime images.

## Changes Summary
- **1 commit**: `286e4c6` - "refactor: update Docker image names to pkg-drs prefix"
- **4 files changed**: 6 insertions(+), 6 deletions(-)

## Files Modified

### 1. `docker/calibration/build.sh`
- Changed: `tier4/drs-calibration:latest` → `tier4/pkg-drs-calibration:latest`

### 2. `docker/calibration/run.sh`
- Changed: `ghcr.io/tier4/drs-calibration:latest` → `ghcr.io/tier4/pkg-drs-calibration:latest`

### 3. `docker/runtime/build.sh`
- Changed: `tier4/drs-runtime:latest` → `tier4/pkg-drs-runtime:latest`

### 4. `docker/runtime/run.sh`
- Changed: `ghcr.io/tier4/drs-runtime:latest` → `ghcr.io/tier4/pkg-drs-runtime:latest`

## Impact
- Updates Docker image naming convention to use `pkg-drs-*` prefix instead of `drs-*`
- Affects both local build commands (`tier4/`) and registry pull commands (`ghcr.io/tier4/`)
- Applies to both calibration and runtime Docker images

This change aligns the Docker image naming with a package registry convention.

