### PR TITLE
feat(ptp): add support for NTP-based time synchronization

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -93,7 +93,8 @@
     "wlan",
     "wpasupplicant",
     "wsize",
-    "zoneinfo"
+    "zoneinfo",
+    "chronyd"
   ],
   "import": ["https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"],
   "useGitignore": true

--- a/ansible/inventory/host_vars/ecu0.yaml
+++ b/ansible/inventory/host_vars/ecu0.yaml
@@ -11,6 +11,8 @@ netplan_files:
 
 # PTP Configuration
 ptp:
+  time_sync_type: GNSS # GNSS or NTP
+  ntp_server: ntp.nict.jp
   master_port: mgbe0
   slave_ports:
     - eqos0

--- a/ansible/inventory/host_vars/ecu1.yaml
+++ b/ansible/inventory/host_vars/ecu1.yaml
@@ -11,6 +11,8 @@ netplan_files:
 
 # PTP Configuration
 ptp:
+  time_sync_type: GNSS # Always use GNSS (Standard PTP) for ECU1 as it is a slave
+  ntp_server: ntp.nict.jp # Placeholder, not used in GNSS mode
   master_port: enP1p1s0
   slave_ports:
     - eqos0

--- a/ansible/roles/ptp/defaults/main.yaml
+++ b/ansible/roles/ptp/defaults/main.yaml
@@ -1,4 +1,12 @@
 ptp:
+  # Time synchronization type: 'GNSS' or 'NTP'
+  # GNSS: Use GNSS/INS as Grandmaster (GM) for PTP
+  # NTP: Sync system time with NTP once at startup, then use PTP for device synchronization
+  time_sync_type: GNSS
+
+  # NTP Server (used when time_sync_type is NTP)
+  ntp_server: ntp.nict.jp
+
   # Port configuration
   master_port: mgbe0
   slave_ports:

--- a/ansible/roles/ptp/tasks/main.yaml
+++ b/ansible/roles/ptp/tasks/main.yaml
@@ -6,6 +6,47 @@
     update_cache: false
   become: true
 
+- name: Install chrony for NTP time synchronization
+  ansible.builtin.apt:
+    name:
+      - chrony
+    state: present
+    update_cache: false
+  become: true
+  when: ptp.time_sync_type == 'NTP'
+
+- name: Ensure chrony configuration directory exists
+  ansible.builtin.file:
+    path: /etc/chrony/chrony.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  become: true
+  when: ptp.time_sync_type == 'NTP'
+
+- name: Configure chrony for NTP synchronization
+  ansible.builtin.copy:
+    content: |
+      # NTP server configuration for PTP time sync type
+      server {{ ptp.ntp_server }} iburst
+      makestep 1.0 3
+    dest: /etc/chrony/chrony.conf.d/drs-ntp.conf
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  when: ptp.time_sync_type == 'NTP'
+
+- name: Disable chrony service (used only for one-time sync in phc2sys.sh)
+  ansible.builtin.systemd:
+    name: chrony
+    enabled: false
+    state: stopped
+  become: true
+  when: ptp.time_sync_type == 'NTP'
+  ignore_errors: true
+
 - name: Create service directory
   ansible.builtin.file:
     path: "{{ ptp_service_dir }}"
@@ -15,7 +56,7 @@
     mode: "0755"
   become: true
 
-- name: Deploy ptp4l configuration file
+- name: Deploy ptp4l configuration file (GNSS mode)
   ansible.builtin.template:
     src: ptp4l.conf.j2
     dest: "{{ ptp_service_dir }}/ptp4l.conf"
@@ -23,8 +64,19 @@
     group: root
     mode: "0644"
   become: true
+  when: ptp.time_sync_type == 'GNSS'
 
-- name: Deploy phc2sys startup script
+- name: Deploy ptp4l configuration file (NTP mode)
+  ansible.builtin.template:
+    src: ptp4l.conf.ntp.j2
+    dest: "{{ ptp_service_dir }}/ptp4l.conf"
+    owner: root
+    group: root
+    mode: "0644"
+  become: true
+  when: ptp.time_sync_type == 'NTP'
+
+- name: Deploy phc2sys startup script (GNSS mode)
   ansible.builtin.template:
     src: phc2sys.sh.j2
     dest: "{{ ptp_service_dir }}/phc2sys.sh"
@@ -32,6 +84,17 @@
     group: root
     mode: "0755"
   become: true
+  when: ptp.time_sync_type == 'GNSS'
+
+- name: Deploy phc2sys startup script (NTP mode)
+  ansible.builtin.template:
+    src: phc2sys.sh.ntp.j2
+    dest: "{{ ptp_service_dir }}/phc2sys.sh"
+    owner: root
+    group: root
+    mode: "0755"
+  become: true
+  when: ptp.time_sync_type == 'NTP'
 
 - name: Deploy ptp4l systemd service file
   ansible.builtin.template:

--- a/ansible/roles/ptp/templates/phc2sys.sh.ntp.j2
+++ b/ansible/roles/ptp/templates/phc2sys.sh.ntp.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PHC synchronization script
+
+# Exit on error
+set -e
+
+# Synchronize system time with NTP once at startup
+chronyd -q -t 15 -n 'server {{ ptp.ntp_server }} iburst'
+
+# Initialize PHCs
+{% for port in ptp.slave_ports %}
+/usr/sbin/phc_ctl {{ port }} set
+{% endfor %}
+
+# Synchronize PHCs with system clock (NTP-synchronized system time)
+# System time (CLOCK_REALTIME) is the source, PHCs are the targets
+{% for port in ptp.slave_ports %}
+/usr/sbin/phc2sys -s CLOCK_REALTIME -c {{ port }} -w -m --step_threshold=1 &
+{% endfor %}
+
+# Wait for all background processes
+wait

--- a/ansible/roles/ptp/templates/ptp4l.conf.ntp.j2
+++ b/ansible/roles/ptp/templates/ptp4l.conf.ntp.j2
@@ -1,0 +1,23 @@
+[global]
+domainNumber            0
+logging_level           6
+step_threshold          1.0
+first_step_threshold    1.0
+tx_timestamp_timeout    1000
+boundary_clock_jbod     1
+clockClass              {{ ptp.clock_class }}
+priority1               {{ ptp.priority1 }}
+priority2               {{ ptp.priority2 }}
+utc_offset              0
+
+time_stamping           hardware
+delay_mechanism         E2E
+network_transport       UDPv4
+twoStepFlag             1
+
+# Slave ports
+{% for port in ptp.slave_ports %}
+[{{ port }}]
+masterOnly              1
+
+{% endfor %}


### PR DESCRIPTION
## Description
This PR introduces a new time synchronization type 'NTP' for the PTP role, allowing the system to synchronize with an NTP server.

## Changes
- Defaults: Added time_sync_type (default: 'GNSS') and ntp_server (default: 'ntp.nict.jp') variables.
- Inventory: Updated ecu0 and ecu1 host variables to include new PTP parameters.
- Templates:
  - Added ptp4l.conf.ntp.j2: Configuration for PTP master without GNSS source.
  - Added phc2sys.sh.ntp.j2: Script to sync system time from NTP and then distribute it to PHCs.
- Tasks:
  - Added tasks to install and configure chrony for one-shot NTP synchronization when in NTP mode.
  - Added logic to deploy appropriate configuration files based on time_sync_type.

## Usage
To switch to NTP mode for ecu0:
1. Update ansible/inventory/host_vars/ecu0.yaml:
```
   ptp:
     time_sync_type: NTP
     ntp_server: ntp.nict.jp
```
2. Run the setup script:
```
   ./drs-setup.sh --tags ptp
```

## Verification on HILS
- Switched the time synchronization type from GNSS to NTP. (Updated ecu0.yaml and executed ./drs-setup.sh --tags ptp.) Confirmed that time synchronization via NTP was active after a reboot.
- Switched the time synchronization type from NTP to GNSS. (Updated ecu0.yaml and executed ./drs-setup.sh --tags ptp.) Confirmed that time synchronization was active with GNSS as the Grandmaster (GM) after a reboot.