### PR TITLE
fix: enable dnsmasq restart on failure

### DIFF
--- a/ansible/roles/raspi_dhcp/tasks/main.yml
+++ b/ansible/roles/raspi_dhcp/tasks/main.yml
@@ -11,6 +11,19 @@
     state: started
     enabled: true
 
+- name: Create dnsmasq service override directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/dnsmasq.service.d
+    state: directory
+    mode: "0755"
+
+- name: Configure dnsmasq service override
+  ansible.builtin.template:
+    src: override.conf.j2
+    dest: /etc/systemd/system/dnsmasq.service.d/override.conf
+    mode: "0644"
+  register: dnsmasq_override
+
 - name: Configure dnsmasq for DHCP only (disable DNS)
   ansible.builtin.template:
     src: 99-drs-dhcp.conf.j2
@@ -18,7 +31,13 @@
     backup: true
     mode: "0644"
 
-- name: Enable dnsmasq service
+- name: Force systemd reload if override changed
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: dnsmasq_override.changed
+
+- name: Enable and start dnsmasq service
   ansible.builtin.systemd:
     name: dnsmasq
     enabled: true
+    state: started

--- a/ansible/roles/raspi_dhcp/templates/override.conf.j2
+++ b/ansible/roles/raspi_dhcp/templates/override.conf.j2
@@ -1,0 +1,7 @@
+[Unit]
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Restart=on-failure
+RestartSec=5


### PR DESCRIPTION
## Description
This PR adds a systemd override configuration for \`dnsmasq\` to enable automatic restart on failure.
This change resolves an issue where the Dashboard could not be accessed via WiFi.

## Motivation
Currently, \`dnsmasq\` may fail to start if the configured network interfaces (e.g., \`wlan0\`) are not yet available during the boot process. Since the default systemd service configuration does not include a retry mechanism, the service remains in a failed state.

## Changes
- Added \`override.conf.j2\` template to configure \`Restart=on-failure\` and \`RestartSec=5\` for the \`dnsmasq\` service.
- Updated \`raspi_dhcp\` role to deploy the override configuration file to \`/etc/systemd/system/dnsmasq.service.d/override.conf\`.

## Verification
- After applying the raspi_dhcp role and rebooting, I confirmed that dnsmasq started successfully.