### PR TITLE
refactor: discard redundant topics

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -59,6 +59,7 @@
     "mgmt",
     "mmcblk",
     "mminit",
+    "navsat",
     "ncom",
     "nebula",
     "netfilter",
@@ -95,6 +96,8 @@
     "wsize",
     "zoneinfo"
   ],
-  "import": ["https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"],
+  "import": [
+    "https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"
+  ],
   "useGitignore": true
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -96,8 +96,6 @@
     "wsize",
     "zoneinfo"
   ],
-  "import": [
-    "https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"
-  ],
+  "import": ["https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"],
   "useGitignore": true
 }

--- a/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
+++ b/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
@@ -31,6 +31,14 @@ topics:
     max_rate: 15.0
   - name: /tf_static # tf
   - name: /sensing/ins/oxts/imu
+    min_rate: 25.0
+    max_rate: 110.0
   - name: /sensing/ins/oxts/nav_sat_fix
+    min_rate: 2.5
+    max_rate: 11.0
   - name: /sensing/ins/oxts/odometry
+    min_rate: 12.5
+    max_rate: 55.0
   - name: /sensing/ins/oxts/velocity
+    min_rate: 12.5
+    max_rate: 55.0

--- a/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
+++ b/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
@@ -31,11 +31,6 @@ topics:
     max_rate: 15.0
   - name: /tf_static # tf
   - name: /sensing/ins/oxts/imu
-  - name: /sensing/ins/oxts/imu_bias
-  - name: /sensing/ins/oxts/lever_arm
   - name: /sensing/ins/oxts/nav_sat_fix
-  - name: /sensing/ins/oxts/nav_sat_ref
-  - name: /sensing/ins/oxts/ncom
   - name: /sensing/ins/oxts/odometry
   - name: /sensing/ins/oxts/velocity
-#  - name: /vehicle/from_can_bus

--- a/src/individual_params/config/default/oxts_driver.param.yaml
+++ b/src/individual_params/config/default/oxts_driver.param.yaml
@@ -14,7 +14,7 @@ oxts_driver:
 #===============================================================================
     ## Rate is in Hz. 0 Hz => Message will not be published
     ### Configure sample rate of NCom (do not exceed output rate of ncom)
-    ncom_rate               : 100
+    ncom_rate               : 0
 
 #===============================================================================
     ## Timing - how to timestamp messages published by the ROS driver

--- a/src/individual_params/config/default/oxts_ins.param.yaml
+++ b/src/individual_params/config/default/oxts_ins.param.yaml
@@ -10,7 +10,7 @@ oxts_ins:
     ### Overall topic names take the form "~/{x_topic}"
     ### where topic prefix is defined in the oxts_driver yaml
     ### Configure NCom (do not exceed output rate of ncom)
-    ncom_rate               : 100
+    ncom_rate               : 0
     ncom_topic              : "ncom"
     ### Publish string message
     pub_string_rate         : 0
@@ -36,13 +36,13 @@ oxts_ins:
     pub_ecef_pos_rate       : 0
     ecef_pos_topic          : "ecef_pos"
     ### Publish OxTS NavSatRef message
-    pub_nav_sat_ref_rate    : 10
+    pub_nav_sat_ref_rate    : 0
     nav_sat_ref_topic       : "nav_sat_ref"
     ### Publish OxTS Lever Arm message
-    pub_lever_arm_rate      : 5
+    pub_lever_arm_rate      : 0
     lever_arm_topic         : "lever_arm"
     ### Publish OxTS IMU Bias message
-    pub_imu_bias_rate       : 5
+    pub_imu_bias_rate       : 0
     imu_bias_topic          : "imu_bias"
     ### Publish Imu message
     pub_imu_flag            : true

--- a/src/individual_params/config/default/oxts_ins.param.yaml
+++ b/src/individual_params/config/default/oxts_ins.param.yaml
@@ -47,7 +47,7 @@ oxts_ins:
     ### Publish Imu message
     pub_imu_flag            : true
     imu_topic               : "imu"
-    ### Broadcast TF messages for rviz visualisation
+    ### Broadcast TF messages for rviz visualization
     pub_tf_flag             : false
     ### Source of the local reference frame
     #### 0 - NCom LRF


### PR DESCRIPTION
## Summary
This PR optimizes the OxTS sensor configuration by disabling redundant topic publishing and adding rate monitoring for critical topics.

## Changes

### OxTS Driver Configuration
- **Disabled NCom publishing**: Set `ncom_rate` to 0 in both `oxts_driver` and `oxts_ins` configurations
  - NCom is a proprietary binary format that was being published but not used

### OxTS INS Topics
Disabled publishing of the following low-priority diagnostic topics:
- `nav_sat_ref` - Reference position for navigation
- `lever_arm` - Sensor offset information  
- `imu_bias` - IMU bias estimates

### Recording Configuration
- **Removed redundant topics** from recording list:
  - `/sensing/ins/oxts/imu_bias`
  - `/sensing/ins/oxts/lever_arm`
  - `/sensing/ins/oxts/nav_sat_ref`
  - `/sensing/ins/oxts/ncom`

- **Added rate monitoring** for essential topics with expected frequency ranges:
  - `/sensing/ins/oxts/imu`: 25-110 Hz
  - `/sensing/ins/oxts/nav_sat_fix`: 2.5-11 Hz
  - `/sensing/ins/oxts/odometry`: 12.5-55 Hz
  - `/sensing/ins/oxts/velocity`: 12.5-55 Hz

### Other Changes
- Added `navsat` to spell check dictionary
- Fixed typo: "visualisation" → "visualization"

## Impact
- **Reduced data volume**: Eliminated 4 unused topics from recording
- **Improved monitoring**: Added rate checks to detect sensor issues early
- **Cleaner configuration**: Removed unnecessary topic publications at the source

## Files Changed
4 files modified (+15, -11 lines)