### PR TITLE
fix: rollback discard redundant topics

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -59,6 +59,7 @@
     "mgmt",
     "mmcblk",
     "mminit",
+    "navsat",
     "ncom",
     "nebula",
     "netfilter",

--- a/.cspell.json
+++ b/.cspell.json
@@ -59,7 +59,6 @@
     "mgmt",
     "mmcblk",
     "mminit",
-    "navsat",
     "ncom",
     "nebula",
     "netfilter",

--- a/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
+++ b/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
@@ -31,14 +31,11 @@ topics:
     max_rate: 15.0
   - name: /tf_static # tf
   - name: /sensing/ins/oxts/imu
-    min_rate: 25.0
-    max_rate: 110.0
+  - name: /sensing/ins/oxts/imu_bias
+  - name: /sensing/ins/oxts/lever_arm
   - name: /sensing/ins/oxts/nav_sat_fix
-    min_rate: 2.5
-    max_rate: 11.0
+  - name: /sensing/ins/oxts/nav_sat_ref
+  - name: /sensing/ins/oxts/ncom
   - name: /sensing/ins/oxts/odometry
-    min_rate: 12.5
-    max_rate: 55.0
   - name: /sensing/ins/oxts/velocity
-    min_rate: 12.5
-    max_rate: 55.0
+#  - name: /vehicle/from_can_bus

--- a/src/individual_params/config/default/oxts_driver.param.yaml
+++ b/src/individual_params/config/default/oxts_driver.param.yaml
@@ -14,7 +14,7 @@ oxts_driver:
 #===============================================================================
     ## Rate is in Hz. 0 Hz => Message will not be published
     ### Configure sample rate of NCom (do not exceed output rate of ncom)
-    ncom_rate               : 0
+    ncom_rate               : 100
 
 #===============================================================================
     ## Timing - how to timestamp messages published by the ROS driver

--- a/src/individual_params/config/default/oxts_ins.param.yaml
+++ b/src/individual_params/config/default/oxts_ins.param.yaml
@@ -10,7 +10,7 @@ oxts_ins:
     ### Overall topic names take the form "~/{x_topic}"
     ### where topic prefix is defined in the oxts_driver yaml
     ### Configure NCom (do not exceed output rate of ncom)
-    ncom_rate               : 0
+    ncom_rate               : 100
     ncom_topic              : "ncom"
     ### Publish string message
     pub_string_rate         : 0
@@ -36,18 +36,18 @@ oxts_ins:
     pub_ecef_pos_rate       : 0
     ecef_pos_topic          : "ecef_pos"
     ### Publish OxTS NavSatRef message
-    pub_nav_sat_ref_rate    : 0
+    pub_nav_sat_ref_rate    : 10
     nav_sat_ref_topic       : "nav_sat_ref"
     ### Publish OxTS Lever Arm message
-    pub_lever_arm_rate      : 0
+    pub_lever_arm_rate      : 5
     lever_arm_topic         : "lever_arm"
     ### Publish OxTS IMU Bias message
-    pub_imu_bias_rate       : 0
+    pub_imu_bias_rate       : 5
     imu_bias_topic          : "imu_bias"
     ### Publish Imu message
     pub_imu_flag            : true
     imu_topic               : "imu"
-    ### Broadcast TF messages for rviz visualization
+    ### Broadcast TF messages for rviz visualisation
     pub_tf_flag             : false
     ### Source of the local reference frame
     #### 0 - NCom LRF

--- a/src/individual_params/config/default/oxts_ins.param.yaml
+++ b/src/individual_params/config/default/oxts_ins.param.yaml
@@ -47,7 +47,7 @@ oxts_ins:
     ### Publish Imu message
     pub_imu_flag            : true
     imu_topic               : "imu"
-    ### Broadcast TF messages for rviz visualisation
+    ### Broadcast TF messages for rviz visualization
     pub_tf_flag             : false
     ### Source of the local reference frame
     #### 0 - NCom LRF


### PR DESCRIPTION
This pull request updates the configuration for the OxTS INS and driver components to enable and set appropriate rates for several previously disabled topics and message types. The changes improve the recording and publishing of INS-related data by activating new topics and increasing message rates, which will enhance data availability for downstream consumers.

**OxTS INS and Driver Configuration Updates**

* Enabled publishing of NCom messages and set the rate to 100 Hz in both `oxts_driver` and `oxts_ins` configurations, ensuring high-frequency output for INS data. [[1]](diffhunk://#diff-0d8574316f60c28555ad2c3d7fd88525624ef656be9a4fefef3b347733c73a2aL17-R17) [[2]](diffhunk://#diff-8528b2906d87fb960d7b868a5df71a7b9a7329140b9cb85da146ee25d4a4980bL13-R13)
* Activated and set rates for additional INS message types in `oxts_ins`:
  * `nav_sat_ref` at 10 Hz
  * `lever_arm` at 5 Hz
  * `imu_bias` at 5 Hz

**Topic List Updates**

* Added new topics to the recorder configuration: `/sensing/ins/oxts/imu_bias`, `/sensing/ins/oxts/lever_arm`, `/sensing/ins/oxts/nav_sat_ref`, and `/sensing/ins/oxts/ncom`, while removing rate constraints from existing topics.
