### PR TITLE
feat(sync_to_nas): add configurable chmod mode for rsync transfers

### DIFF
--- a/ansible/roles/sync_to_nas/defaults/main.yaml
+++ b/ansible/roles/sync_to_nas/defaults/main.yaml
@@ -15,3 +15,6 @@ sync_to_nas_lock_file: /var/run/sync_to_nas.lock
 # Service resource limits
 sync_to_nas_cpu_quota: 50%
 sync_to_nas_io_weight: 10
+
+# chmod settings
+sync_to_nas_chmod_mode: "644"

--- a/ansible/roles/sync_to_nas/templates/sync_to_nas.sh.j2
+++ b/ansible/roles/sync_to_nas/templates/sync_to_nas.sh.j2
@@ -73,6 +73,7 @@ find "$SOURCE_DIR" -name "*.mcap" -type f -printf '%T@ %p\n' | sort -n | cut -d'
         --bwlimit="$RSYNC_BW_LIMIT" \
         --checksum \
         --no-progress \
+        --chmod={{ sync_to_nas_chmod_mode }} \
         "$mcap_file" \
         "$dest_file"; then
 


### PR DESCRIPTION
- Add sync_to_nas_chmod_mode variable with default value '644'
- Add --chmod option to rsync command in sync_to_nas.sh.j2

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
