### PR TITLE
feat: support seyond lidar in offline launch

### DIFF
--- a/src/drs_launch/launch/drs_offline.launch.xml
+++ b/src/drs_launch/launch/drs_offline.launch.xml
@@ -8,8 +8,9 @@
   <arg name="concatenate_pointcloud" default="False"
        description="If true, pointclouds from all LiDARs will be concatenated into a single topic"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
+  <arg name="lidar_driver_type" default="nebula" description="Type of LiDAR driver to use: nebula or seyond"/>
 
-  <group>
+  <group if="$(eval &quot;'$(var lidar_driver_type)' == 'nebula'&quot;)">
     <push-ros-namespace namespace="sensing"/>
     <group>
       <push-ros-namespace namespace="lidar"/>
@@ -50,6 +51,68 @@
           <arg name="lidar_model" value="RobinW"/>
           <arg name="min_range" value="0.3"/>
           <arg name="max_range" value="200.0"/>
+        </include>
+      </group>
+    </group>
+  </group>
+
+  <group if="$(eval &quot;'$(var lidar_driver_type)' == 'seyond'&quot;)">
+    <push-ros-namespace namespace="sensing"/>
+    <group>
+      <push-ros-namespace namespace="lidar"/>
+      <group>
+        <push-ros-namespace namespace="front"/>
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_seyond.launch.xml">
+          <arg name="lidar_position" value="front"/>
+          <arg name="lidar_model" value="Falcon"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="publish_pointcloud" value="$(var publish_pointcloud)"/>
+          <arg name="calibration_file_path" value=""/>
+          <arg name="sensor_ip" value="192.168.2.201"/>
+          <arg name="host_ip" value="192.168.2.1"/>
+          <arg name="data_port" value="2368"/>
+        </include>
+      </group>
+
+      <group>
+        <push-ros-namespace namespace="right"/>
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_seyond.launch.xml">
+          <arg name="lidar_position" value="right"/>
+          <arg name="lidar_model" value="RobinW"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="publish_pointcloud" value="$(var publish_pointcloud)"/>
+          <arg name="calibration_file_path" value=""/>
+          <arg name="sensor_ip" value="192.168.2.203"/>
+          <arg name="host_ip" value="192.168.2.1"/>
+          <arg name="data_port" value="8010"/>
+        </include>
+      </group>
+
+      <group>
+        <push-ros-namespace namespace="rear"/>
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_seyond.launch.xml">
+          <arg name="lidar_position" value="rear"/>
+          <arg name="lidar_model" value="Falcon"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="publish_pointcloud" value="$(var publish_pointcloud)"/>
+          <arg name="calibration_file_path" value=""/>
+          <arg name="sensor_ip" value="192.168.2.202"/>
+          <arg name="host_ip" value="192.168.2.2"/>
+          <arg name="data_port" value="2369"/>
+        </include>
+      </group>
+
+      <group>
+        <push-ros-namespace namespace="left"/>
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_seyond.launch.xml">
+          <arg name="lidar_position" value="left"/>
+          <arg name="lidar_model" value="RobinW"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="publish_pointcloud" value="$(var publish_pointcloud)"/>
+          <arg name="calibration_file_path" value=""/>
+          <arg name="sensor_ip" value="192.168.2.204"/>
+          <arg name="host_ip" value="192.168.2.2"/>
+          <arg name="data_port" value="8010"/>
         </include>
       </group>
     </group>


### PR DESCRIPTION
## Description
This PR adds support for the Seyond LiDAR driver in the offline launch configuration. It introduces a new argument `lidar_driver_type` to switch between `nebula` (default) and `seyond` drivers, allowing users to process data from vehicles equipped with Seyond LiDARs.

## Changes
- Modified [src/drs_launch/launch/drs_offline.launch.xml](cci:7://file:///home/autoware/workspace/drs-offline/data_recording_system/src/drs_launch/launch/drs_offline.launch.xml:0:0-0:0) to include conditional logic for loading either `nebula` or `seyond` driver configurations based on the `lidar_driver_type` argument.

## Usage
To launch the offline processing with the Seyond driver:

```bash
ros2 launch drs_launch drs_offline.launch publish_tf:=False lidar_driver_type:=seyond
```

## Verification
- [x] **Default / Nebula**: Verified that Nebula packets are decoded correctly when running with default arguments or explicitly setting `lidar_driver_type:=nebula`.
- [x] **Seyond**: Verified that Seyond packets are decoded correctly when running with `lidar_driver_type:=seyond`.