### PR TITLE
feat: add rate monitoring configuration for recording topics

### DIFF
--- a/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
+++ b/ansible/roles/drs_recorder_service/files/record_topics_ecu0.yaml
@@ -1,4 +1,7 @@
 topics:
+  # For camera topics,
+  # min_rate is set to 90% of the expected rate
+  # max_rate is set to 105% of the expected rate
   - name: /sensing/camera/camera0/image_raw/compressed
     min_rate: 18.0
     max_rate: 21.0
@@ -23,6 +26,9 @@ topics:
   - name: /sensing/camera/camera3/camera_info
     min_rate: 18.0
     max_rate: 21.0
+  # For lidar topics,
+  # min_rate is set to 90% of the expected rate
+  # max_rate is set to 150% of the expected rate
   - name: /sensing/lidar/front/nebula_packets
     min_rate: 9.0
     max_rate: 15.0
@@ -30,12 +36,31 @@ topics:
     min_rate: 9.0
     max_rate: 15.0
   - name: /tf_static # tf
+  # For INS topics,
+  # min_rate is set to 60% of the expected rate
+  # max_rate is set to 110% of the expected rate
   - name: /sensing/ins/oxts/imu
+    min_rate: 60.0
+    max_rate: 110.0
   - name: /sensing/ins/oxts/imu_bias
+    min_rate: 3.0
+    max_rate: 6.0
   - name: /sensing/ins/oxts/lever_arm
+    min_rate: 3.0
+    max_rate: 6.0
   - name: /sensing/ins/oxts/nav_sat_fix
+    min_rate: 3.0
+    max_rate: 11.0
   - name: /sensing/ins/oxts/nav_sat_ref
+    min_rate: 3.0
+    max_rate: 11.0
   - name: /sensing/ins/oxts/ncom
+    min_rate: 60.0
+    max_rate: 110.0
   - name: /sensing/ins/oxts/odometry
+    min_rate: 30.0
+    max_rate: 55.0
   - name: /sensing/ins/oxts/velocity
+    min_rate: 30.0
+    max_rate: 55.0
 #  - name: /vehicle/from_can_bus

--- a/ansible/roles/drs_recorder_service/files/record_topics_ecu1.yaml
+++ b/ansible/roles/drs_recorder_service/files/record_topics_ecu1.yaml
@@ -1,4 +1,7 @@
 topics:
+  # For camera topics,
+  # min_rate is set to 90% of the expected rate
+  # max_rate is set to 105% of the expected rate
   - name: /sensing/camera/camera4/image_raw/compressed
     min_rate: 18.0
     max_rate: 21.0
@@ -23,6 +26,9 @@ topics:
   - name: /sensing/camera/camera7/camera_info
     min_rate: 1.0
     max_rate: 50.0
+  # For lidar topics,
+  # min_rate is set to 90% of the expected rate
+  # max_rate is set to 150% of the expected rate
   - name: /sensing/lidar/rear/nebula_packets
     min_rate: 9.0
     max_rate: 15.0


### PR DESCRIPTION
This pull request updates the configuration files for the DRS recorder service to clarify and standardize the expected message rates for different sensor topics. The most important changes are the addition of explanatory comments for camera, lidar, and INS topics, along with explicit rate settings for INS topics to ensure consistent monitoring and validation.

**Documentation and configuration improvements:**

* Added comments to both `record_topics_ecu0.yaml` and `record_topics_ecu1.yaml` explaining the logic behind `min_rate` and `max_rate` settings for camera topics (90%–105% of expected rate) and lidar topics (90%–150% of expected rate). [[1]](diffhunk://#diff-ef7ea2727bd5419b7cc81ee7ee6d53a98ca61273d7cb55fe25bdb30aac2b6debR2-R4) [[2]](diffhunk://#diff-ef7ea2727bd5419b7cc81ee7ee6d53a98ca61273d7cb55fe25bdb30aac2b6debR29-R65) [[3]](diffhunk://#diff-75fb5d9c38a9dcd4f5be73ad97e2cb67d2d4fde09b6200f77c01b74d17500755R2-R4) [[4]](diffhunk://#diff-75fb5d9c38a9dcd4f5be73ad97e2cb67d2d4fde09b6200f77c01b74d17500755R29-R31)
* Added comments and explicit `min_rate` and `max_rate` values for INS topics in `record_topics_ecu0.yaml`, setting thresholds at 60%–110% (or 3–11, 3–6, 30–55 depending on the topic) of expected rates to improve clarity and monitoring.
