### PR TITLE
fix: set eth0 optional to true to prevent systemd-networkd-wait-online failure

### DIFF
--- a/ansible/roles/raspi_network/templates/99-drs.yaml.j2
+++ b/ansible/roles/raspi_network/templates/99-drs.yaml.j2
@@ -6,7 +6,7 @@ network:
     eth0:
       dhcp4: false
       dhcp6: false
-      optional: false
+      optional: true
     wlan0:
       addresses: [{{ wlan0_address }}]
       dhcp4: no


### PR DESCRIPTION
## Summary

This PR fixes an issue where `systemd-networkd-wait-online` fails when `eth0` is configured with `optional: false` but has no addresses and both DHCP4 and DHCP6 are disabled.

## Problem

When a network interface has:
- No static addresses configured
- `dhcp4: false`
- `dhcp6: false`
- `optional: false`

`systemd-networkd-wait-online` will wait for the interface to become online, which will never happen since there's no way for it to obtain an address. This results in a timeout failure.

## Solution

Changed `eth0` configuration from `optional: false` to `optional: true`. This tells `systemd-networkd-wait-online` not to wait for this interface, preventing the failure.

## Changes

- `ansible/roles/raspi_network/templates/99-drs.yaml.j2`: Changed `eth0.optional` from `false` to `true`

## Related

This follows the same pattern used for other interfaces like `lte0` and `eth0.20`, which also use `optional: true` when they might not always be available or configured.