### PR TITLE
fix: add --local option for Docker run scripts and improve entrypoint

### DIFF
--- a/docker/calibration/run.sh
+++ b/docker/calibration/run.sh
@@ -56,7 +56,7 @@ BASE_DOCKER_OPTS=(
 )
 
 # Mount XAUTHORITY if it is set
-if [[ -n "${XAUTHORITY}" ]]; then
+if [[ -n ${XAUTHORITY} ]]; then
     BASE_DOCKER_OPTS+=(-v "${XAUTHORITY}:${XAUTHORITY}")
 fi
 
@@ -107,7 +107,7 @@ done
 # echo "Command args: ${COMMAND_ARGS[@]}"
 
 # Select Docker image based on --local flag
-if [[ "$USE_LOCAL_IMAGE" == true ]]; then
+if [[ $USE_LOCAL_IMAGE == true ]]; then
     DOCKER_IMAGE="tier4/pkg-drs-calibration:latest"
 else
     DOCKER_IMAGE="ghcr.io/tier4/pkg-drs-calibration:latest"

--- a/docker/calibration/run.sh
+++ b/docker/calibration/run.sh
@@ -5,18 +5,22 @@ set -e
 # Help message
 show_help() {
     cat <<EOF
-Usage: $(basename "$0") [--option DOCKER_OPTIONS] [--] COMMAND [ARGS...]
+Usage: $(basename "$0") [--local] [--option DOCKER_OPTIONS] [--] COMMAND [ARGS...]
 
 Launch a Docker container with GPU and GUI support
 
 Options:
-    --option    Treat following arguments as additional Docker options
-    --          Treat following arguments as commands to run inside the container
-    --help, -h  Show this help message
+    --local      Use local Docker image (tier4/pkg-drs-calibration:latest)
+    --option     Treat following arguments as additional Docker options
+    --           Treat following arguments as commands to run inside the container
+    --help, -h   Show this help message
 
 Examples:
     # Basic usage
     $(basename "$0") python test.py
+
+    # Use local image
+    $(basename "$0") --local python test.py
 
     # Add volume mount
     $(basename "$0") --option -v /home/user/data:/data -- python test.py
@@ -51,13 +55,23 @@ BASE_DOCKER_OPTS=(
     -v "/etc/localtime:/etc/localtime:ro"
 )
 
+# Mount XAUTHORITY if it is set
+if [[ -n "${XAUTHORITY}" ]]; then
+    BASE_DOCKER_OPTS+=(-v "${XAUTHORITY}:${XAUTHORITY}")
+fi
+
 # Additional Docker options and command arguments
+USE_LOCAL_IMAGE=false
 EXTRA_DOCKER_OPTS=()
 COMMAND_ARGS=()
 PARSING_MODE="command"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
+    --local)
+        USE_LOCAL_IMAGE=true
+        shift
+        ;;
     --option)
         PARSING_MODE="docker"
         shift
@@ -72,7 +86,7 @@ while [[ $# -gt 0 ]]; do
             if [[ $1 == -* ]]; then
                 EXTRA_DOCKER_OPTS+=("$1")
                 shift
-                if [[ $# -gt 0 && $1 != -* && $1 != "--" && $1 != "--option" ]]; then
+                if [[ $# -gt 0 && $1 != -* && $1 != "--" && $1 != "--option" && $1 != "--local" ]]; then
                     EXTRA_DOCKER_OPTS+=("$1")
                     shift
                 fi
@@ -92,5 +106,12 @@ done
 # echo "Extra Docker opts: ${EXTRA_DOCKER_OPTS[@]}"
 # echo "Command args: ${COMMAND_ARGS[@]}"
 
+# Select Docker image based on --local flag
+if [[ "$USE_LOCAL_IMAGE" == true ]]; then
+    DOCKER_IMAGE="tier4/pkg-drs-calibration:latest"
+else
+    DOCKER_IMAGE="ghcr.io/tier4/pkg-drs-calibration:latest"
+fi
+
 # Execute Docker command
-docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" ghcr.io/tier4/pkg-drs-calibration:latest "${COMMAND_ARGS[@]}"
+docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" "$DOCKER_IMAGE" "${COMMAND_ARGS[@]}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,7 +36,8 @@ else
     cd "$HOME"
 
     # Prepare runtime directory
-    mkdir -m 700 /run/user/$USER_ID
+    mkdir -p /run/user/$USER_ID
+    chmod 700 /run/user/$USER_ID
     chown "$USER_NAME":"$GROUP_NAME" /run/user/$USER_ID
 
     # Execute the command as the user

--- a/docker/runtime/run.sh
+++ b/docker/runtime/run.sh
@@ -5,18 +5,22 @@ set -e
 # Help message
 show_help() {
     cat <<EOF
-Usage: $(basename "$0") [--option DOCKER_OPTIONS] [--] COMMAND [ARGS...]
+Usage: $(basename "$0") [--local] [--option DOCKER_OPTIONS] [--] COMMAND [ARGS...]
 
 Launch a Docker container with GPU and GUI support
 
 Options:
-    --option    Treat following arguments as additional Docker options
-    --          Treat following arguments as commands to run inside the container
-    --help, -h  Show this help message
+    --local      Use local Docker image (tier4/pkg-drs-runtime:latest)
+    --option     Treat following arguments as additional Docker options
+    --           Treat following arguments as commands to run inside the container
+    --help, -h   Show this help message
 
 Examples:
     # Basic usage
     $(basename "$0") python test.py
+
+    # Use local image
+    $(basename "$0") --local python test.py
 
     # Add volume mount
     $(basename "$0") --option -v /home/user/data:/data -- python test.py
@@ -51,13 +55,23 @@ BASE_DOCKER_OPTS=(
     -v "/etc/localtime:/etc/localtime:ro"
 )
 
+# Mount XAUTHORITY if it is set
+if [[ -n "${XAUTHORITY}" ]]; then
+    BASE_DOCKER_OPTS+=(-v "${XAUTHORITY}:${XAUTHORITY}")
+fi
+
 # Additional Docker options and command arguments
+USE_LOCAL_IMAGE=false
 EXTRA_DOCKER_OPTS=()
 COMMAND_ARGS=()
 PARSING_MODE="command"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
+    --local)
+        USE_LOCAL_IMAGE=true
+        shift
+        ;;
     --option)
         PARSING_MODE="docker"
         shift
@@ -72,7 +86,7 @@ while [[ $# -gt 0 ]]; do
             if [[ $1 == -* ]]; then
                 EXTRA_DOCKER_OPTS+=("$1")
                 shift
-                if [[ $# -gt 0 && $1 != -* && $1 != "--" && $1 != "--option" ]]; then
+                if [[ $# -gt 0 && $1 != -* && $1 != "--" && $1 != "--option" && $1 != "--local" ]]; then
                     EXTRA_DOCKER_OPTS+=("$1")
                     shift
                 fi
@@ -92,5 +106,12 @@ done
 # echo "Extra Docker opts: ${EXTRA_DOCKER_OPTS[@]}"
 # echo "Command args: ${COMMAND_ARGS[@]}"
 
+# Select Docker image based on --local flag
+if [[ "$USE_LOCAL_IMAGE" == true ]]; then
+    DOCKER_IMAGE="tier4/pkg-drs-runtime:latest"
+else
+    DOCKER_IMAGE="ghcr.io/tier4/pkg-drs-runtime:latest"
+fi
+
 # Execute Docker command
-docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" ghcr.io/tier4/pkg-drs-runtime:latest "${COMMAND_ARGS[@]}"
+docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" "$DOCKER_IMAGE" "${COMMAND_ARGS[@]}"

--- a/docker/runtime/run.sh
+++ b/docker/runtime/run.sh
@@ -56,7 +56,7 @@ BASE_DOCKER_OPTS=(
 )
 
 # Mount XAUTHORITY if it is set
-if [[ -n "${XAUTHORITY}" ]]; then
+if [[ -n ${XAUTHORITY} ]]; then
     BASE_DOCKER_OPTS+=(-v "${XAUTHORITY}:${XAUTHORITY}")
 fi
 
@@ -107,7 +107,7 @@ done
 # echo "Command args: ${COMMAND_ARGS[@]}"
 
 # Select Docker image based on --local flag
-if [[ "$USE_LOCAL_IMAGE" == true ]]; then
+if [[ $USE_LOCAL_IMAGE == true ]]; then
     DOCKER_IMAGE="tier4/pkg-drs-runtime:latest"
 else
     DOCKER_IMAGE="ghcr.io/tier4/pkg-drs-runtime:latest"


### PR DESCRIPTION
## Changes

- Added `--local` option to Docker run scripts to use local Docker images
- Added automatic XAUTHORITY mount support when the environment variable is set
- Improved `/run/user/$USER_ID` directory creation in entrypoint.sh (separated `mkdir -p` and `chmod`)

## Modified Files

- `docker/calibration/run.sh`
- `docker/runtime/run.sh`
- `docker/entrypoint.sh`

## Usage

```bash
# Use local image
./docker/runtime/run.sh --local --option -v ~/cyclonedds.xml:/opt/drs/config/cyclonedds.xml -- bash

# Use remote image (default)
./docker/runtime/run.sh --option -v ~/cyclonedds.xml:/opt/drs/config/cyclonedds.xml -- bash
```