### PR TITLE
refactor: replace unix commands with ansible modules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -7,7 +7,6 @@ skip_list:
   - no-handler # Tasks that run when changed should likely be handlers
   - ignore-errors # Use failed_when and specify error conditions
   - risky-shell-pipe # Shells that use pipes should set the pipefail option
-  - command-instead-of-module # Using command rather than module
   - schema[meta] # Skip meta file schema validation to avoid CI-only errors
 
 warn_list: []

--- a/ansible/roles/anvil_docker/tasks/main.yaml
+++ b/ansible/roles/anvil_docker/tasks/main.yaml
@@ -8,8 +8,15 @@
     cache_valid_time: 3600
   become: true
 
-- name: Download and install Docker
-  ansible.builtin.shell: curl https://get.docker.com | sh
+- name: Download Docker installation script
+  ansible.builtin.get_url:
+    url: https://get.docker.com
+    dest: /tmp/get-docker.sh
+    mode: "0755"
+  become: true
+
+- name: Install Docker
+  ansible.builtin.command: /bin/sh /tmp/get-docker.sh
   args:
     creates: /usr/bin/docker
   become: true
@@ -72,9 +79,13 @@
   become: true
 
 - name: Migrate Docker data to new location
-  ansible.builtin.command: rsync -axPS /var/lib/docker/ /mnt/ssd/docker/
+  ansible.posix.synchronize:
+    src: /var/lib/docker/
+    dest: /mnt/ssd/docker/
+    rsync_opts:
+      - -axPS
   become: true
-  changed_when: true
+  delegate_to: "{{ inventory_hostname }}"
 
 - name: Check new Docker data directory size
   ansible.builtin.command: du -csh /mnt/ssd/docker/

--- a/ansible/roles/tailscale/tasks/main.yml
+++ b/ansible/roles/tailscale/tasks/main.yml
@@ -1,8 +1,14 @@
 # Simplified Tailscale installation using official script
 
-- name: Download and run Tailscale official installer
-  ansible.builtin.shell: |
-    curl -fsSL https://tailscale.com/install.sh | sh
+- name: Download Tailscale installation script
+  ansible.builtin.get_url:
+    url: https://tailscale.com/install.sh
+    dest: /tmp/tailscale-install.sh
+    mode: "0755"
+  become: true
+
+- name: Run Tailscale official installer
+  ansible.builtin.command: /bin/sh /tmp/tailscale-install.sh
   args:
     creates: /usr/bin/tailscale
   become: true


### PR DESCRIPTION
## Summary
Replace unix commands (curl, rsync) with Ansible modules to follow best practices and improve idempotency.

## Changes
- **anvil_docker role**: 
  - Replace `curl https://get.docker.com | sh` with `get_url` module + `command` module
  - Replace `rsync` command with `synchronize` module
  - Add `delegate_to` for synchronize to ensure local file synchronization
  
- **tailscale role**:
  - Replace `curl -fsSL https://tailscale.com/install.sh | sh` with `get_url` module + `command` module

- **.ansible-lint**:
  - Remove `command-instead-of-module` from skip list (no longer needed after fixes)

## Benefits
- Better idempotency
- Follows Ansible best practices
- Resolves ansible-lint warnings
- More maintainable code

## Testing
- All ansible-lint checks pass
- Pre-commit hooks pass