### PR TITLE
fix: align ros_domain_id default value with group_vars

### DIFF
--- a/ansible/roles/ros2/defaults/main.yaml
+++ b/ansible/roles/ros2/defaults/main.yaml
@@ -1,2 +1,2 @@
 # ROS 2 configuration defaults
-ros_domain_id: 0
+ros_domain_id: 1


### PR DESCRIPTION
## Summary
This PR aligns the `ros_domain_id` default value in the ros2 role with the value set in `group_vars/all.yaml`.

## Changes
- Changed `ros_domain_id` default from `0` to `1` in `ansible/roles/ros2/defaults/main.yaml`

## Motivation
Previously, the default value in the ros2 role was `0`, while `group_vars/all.yaml` sets it to `1`. Since `group_vars` has higher priority than `role defaults`, the actual value used was always `1`, but the default value was `0`, causing confusion.

## Impact
- Ensures consistency between default value and actual used value
- Prevents confusion when `group_vars/all.yaml` is not loaded (fallback value will now be `1` instead of `0`)
- No breaking changes as the actual behavior remains the same