### PR TITLE
feat: use ros_domain_id variable in docker-compose.yml

### DIFF
--- a/ansible/roles/drs_ros2_bridge_service/tasks/main.yaml
+++ b/ansible/roles/drs_ros2_bridge_service/tasks/main.yaml
@@ -20,9 +20,9 @@
     mode: "0755"
   become: true
 
-- name: Copy docker-compose.yml file
-  ansible.builtin.copy:
-    src: docker-compose.yml
+- name: Deploy docker-compose.yml file
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
     dest: /opt/drs/service/drs_ros2_bridge/docker-compose.yml
     owner: root
     group: root

--- a/ansible/roles/drs_ros2_bridge_service/templates/docker-compose.yml.j2
+++ b/ansible/roles/drs_ros2_bridge_service/templates/docker-compose.yml.j2
@@ -8,7 +8,7 @@ services:
     pid: host
     ipc: host
     environment:
-      - ROS_DOMAIN_ID=1
+      - ROS_DOMAIN_ID={{ ros_domain_id }}
       - ROS_LOCALHOST_ONLY=0
       - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - CYCLONEDDS_URI=file:///opt/drs/config/cyclonedds.xml


### PR DESCRIPTION
## Summary
This PR converts the `docker-compose.yml` file in the `drs_ros2_bridge_service` role to a Jinja2 template, allowing the `ROS_DOMAIN_ID` to be dynamically configured via the `ros_domain_id` variable.

## Changes
- Converted `files/docker-compose.yml` to `templates/docker-compose.yml.j2`
- Changed hardcoded `ROS_DOMAIN_ID=1` to `ROS_DOMAIN_ID={{ ros_domain_id }}`
- Updated task from `ansible.builtin.copy` to `ansible.builtin.template`

## Motivation
Previously, the `ROS_DOMAIN_ID` was hardcoded to `1` in the docker-compose.yml file. This change allows it to be configured dynamically through:
- `group_vars/all.yaml` (currently set to `1`)
- Command line override with `-e "ros_domain_id=42"`
- Host-specific variables in `host_vars/`

## Impact
- Maintains consistency with other ROS 2 configuration (e.g., `ros2` role)
- Allows flexible configuration without modifying template files
- No breaking changes as the default behavior remains the same (uses `ros_domain_id: 1` from `group_vars/all.yaml`)