### PR TITLE
feat: add clang-format to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
             build/|
             install/|
             log/|
-            .*\.(mcap|db3|pcd|bag|bagdb|bin|so|a|o|dylib|dll|exe)|
+            .*\.(mcap|db3|pcd|bag|bin|so|a|o|dylib|dll|exe)|
             .*/json\.hpp$|
           )
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,4 +49,18 @@ repos:
     hooks:
       - id: hadolint
 
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.5
+    hooks:
+      - id: clang-format
+        types_or: [c++, c, cuda]
+        exclude: |
+          (?x)^(
+            build/|
+            install/|
+            log/|
+            .*\.(mcap|db3|pcd|bag|bagdb|bin|so|a|o|dylib|dll|exe)|
+            .*/json\.hpp$|
+          )
+
 exclude: .svg

--- a/src/multi_transform_publisher/src/multi_transform_publisher.cpp
+++ b/src/multi_transform_publisher/src/multi_transform_publisher.cpp
@@ -1,9 +1,12 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
-#include <tf2_ros/static_transform_broadcaster.h>
+
 #include <geometry_msgs/msg/transform_stamped.hpp>
-#include <yaml-cpp/yaml.h>
+
 #include <tf2/LinearMath/Quaternion.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+#include <yaml-cpp/yaml.h>
+
 #include <fstream>
 #include <vector>
 
@@ -11,7 +14,7 @@ class MultiTfPublisher : public rclcpp::Node
 {
 public:
   explicit MultiTfPublisher(const rclcpp::NodeOptions & options)
-    : Node("multi_transform_publisher", options)
+  : Node("multi_transform_publisher", options)
   {
     // Declare parameters
     this->declare_parameter<std::string>("config_file", "");
@@ -38,9 +41,10 @@ public:
     if (periodic_publish_) {
       timer_ = this->create_wall_timer(
         std::chrono::duration<double>(publish_period),
-        std::bind(&MultiTfPublisher::publishTransforms, this)
-      );
-      RCLCPP_INFO(this->get_logger(), "Periodic static publishing enabled with period: %.3f seconds", publish_period);
+        std::bind(&MultiTfPublisher::publishTransforms, this));
+      RCLCPP_INFO(
+        this->get_logger(), "Periodic static publishing enabled with period: %.3f seconds",
+        publish_period);
     } else {
       RCLCPP_INFO(this->get_logger(), "One-time static publishing enabled");
     }
@@ -55,7 +59,7 @@ public:
   }
 
 private:
-  void loadTransforms(const std::string& config_file)
+  void loadTransforms(const std::string & config_file)
   {
     try {
       YAML::Node config = YAML::LoadFile(config_file);
@@ -66,7 +70,7 @@ private:
 
       RCLCPP_INFO(this->get_logger(), "Loaded %zu transforms from config file", transforms_.size());
 
-    } catch (const YAML::Exception& e) {
+    } catch (const YAML::Exception & e) {
       RCLCPP_ERROR(this->get_logger(), "Failed to load YAML file: %s", e.what());
       rclcpp::shutdown();
     }
@@ -80,7 +84,7 @@ private:
 
     // Update timestamps
     auto now = this->get_clock()->now();
-    for (auto& transform : transforms_) {
+    for (auto & transform : transforms_) {
       transform.header.stamp = now;
     }
 
@@ -92,8 +96,9 @@ private:
     }
   }
 
-  void processYamlNode(const YAML::Node& node, const std::string& parent_frame,
-                       std::vector<geometry_msgs::msg::TransformStamped>& transforms)
+  void processYamlNode(
+    const YAML::Node & node, const std::string & parent_frame,
+    std::vector<geometry_msgs::msg::TransformStamped> & transforms)
   {
     for (YAML::const_iterator it = node.begin(); it != node.end(); ++it) {
       std::string frame_id = it->first.as<std::string>();
@@ -104,27 +109,28 @@ private:
       }
       // If this contains transform data
       else if (it->second.IsMap() && hasTransformFields(it->second)) {
-        geometry_msgs::msg::TransformStamped transform = createTransform(parent_frame, frame_id, it->second);
+        geometry_msgs::msg::TransformStamped transform =
+          createTransform(parent_frame, frame_id, it->second);
         transforms.push_back(transform);
 
         // If this is a camera link and we need to publish optical link
         if (publish_camera_optical_link_ && frame_id.find("/camera_link") != std::string::npos) {
-          geometry_msgs::msg::TransformStamped optical_transform = createCameraOpticalTransform(frame_id);
+          geometry_msgs::msg::TransformStamped optical_transform =
+            createCameraOpticalTransform(frame_id);
           transforms.push_back(optical_transform);
         }
       }
     }
   }
 
-  bool hasTransformFields(const YAML::Node& node)
+  bool hasTransformFields(const YAML::Node & node)
   {
-    return node["x"] && node["y"] && node["z"] &&
-           node["roll"] && node["pitch"] && node["yaw"];
+    return node["x"] && node["y"] && node["z"] && node["roll"] && node["pitch"] && node["yaw"];
   }
 
-  geometry_msgs::msg::TransformStamped createTransform(const std::string& parent_frame,
-                                                       const std::string& child_frame,
-                                                       const YAML::Node& transform_data)
+  geometry_msgs::msg::TransformStamped createTransform(
+    const std::string & parent_frame, const std::string & child_frame,
+    const YAML::Node & transform_data)
   {
     geometry_msgs::msg::TransformStamped transform;
     transform.header.stamp = this->get_clock()->now();
@@ -152,13 +158,15 @@ private:
     return transform;
   }
 
-  geometry_msgs::msg::TransformStamped createCameraOpticalTransform(const std::string& camera_link_frame)
+  geometry_msgs::msg::TransformStamped createCameraOpticalTransform(
+    const std::string & camera_link_frame)
   {
     geometry_msgs::msg::TransformStamped transform;
     transform.header.stamp = this->get_clock()->now();
     transform.header.frame_id = camera_link_frame;
 
-    // Extract camera name from frame_id (e.g., "camera0/camera_link" -> "camera0/camera_optical_link")
+    // Extract camera name from frame_id (e.g., "camera0/camera_link" ->
+    // "camera0/camera_optical_link")
     std::string optical_frame = camera_link_frame;
     size_t pos = optical_frame.find("/camera_link");
     if (pos != std::string::npos) {

--- a/src/periodic_transform_publisher/include/periodic_transform_publisher/broadcaster.hpp
+++ b/src/periodic_transform_publisher/include/periodic_transform_publisher/broadcaster.hpp
@@ -5,13 +5,14 @@
  * https://github.com/ros2/geometry2/blob/humble/tf2_ros/src/static_transform_broadcaster_node.cpp
  */
 
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/static_transform_broadcaster.h"
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+
 #include <memory>
 #include <random>
 #include <string>
-
-#include "rclcpp/rclcpp.hpp"
-#include "tf2_ros/static_transform_broadcaster.h"
-#include "geometry_msgs/msg/transform_stamped.hpp"
 
 std::string get_unique_node_name()
 {
@@ -37,10 +38,10 @@ std::string get_unique_node_name()
 
 class Broadcaster : public rclcpp::Node
 {
- public:
+public:
   explicit Broadcaster(const rclcpp::NodeOptions & options)
-      : rclcpp::Node(get_unique_node_name(), options) {
-
+  : rclcpp::Node(get_unique_node_name(), options)
+  {
     rcl_interfaces::msg::ParameterDescriptor descriptor;
     descriptor.read_only = true;
 
@@ -51,37 +52,37 @@ class Broadcaster : public rclcpp::Node
     tf_msg_.transform.rotation.y = this->declare_parameter("rotation.y", 0.0, descriptor);
     tf_msg_.transform.rotation.z = this->declare_parameter("rotation.z", 0.0, descriptor);
     tf_msg_.transform.rotation.w = this->declare_parameter("rotation.w", 1.0, descriptor);
-    tf_msg_.header.frame_id = this->declare_parameter("frame_id", std::string("/frame"), descriptor);
+    tf_msg_.header.frame_id =
+      this->declare_parameter("frame_id", std::string("/frame"), descriptor);
     tf_msg_.child_frame_id =
-        this->declare_parameter("child_frame_id", std::string("/child"), descriptor);
+      this->declare_parameter("child_frame_id", std::string("/child"), descriptor);
 
     double interval_sec = this->declare_parameter("interval_sec", 1.0, descriptor);
 
     // check frame_id != child_frame_id
     if (tf_msg_.header.frame_id == tf_msg_.child_frame_id) {
       RCLCPP_ERROR(
-          this->get_logger(),
-          "cannot publish transform from %s to %s, exiting",
-          tf_msg_.header.frame_id.c_str(), tf_msg_.child_frame_id.c_str()
-      );
+        this->get_logger(), "cannot publish transform from %s to %s, exiting",
+        tf_msg_.header.frame_id.c_str(), tf_msg_.child_frame_id.c_str());
       throw std::runtime_error("child_frame_id cannot equal frame_id");
     }
 
     tf_broadcaster_ = std::make_unique<tf2_ros::StaticTransformBroadcaster>(*this);
-    timer_ = rclcpp::create_timer(this, get_clock(), rclcpp::Duration::from_seconds(interval_sec),
-                                  std::bind(&Broadcaster::callback, this));
+    timer_ = rclcpp::create_timer(
+      this, get_clock(), rclcpp::Duration::from_seconds(interval_sec),
+      std::bind(&Broadcaster::callback, this));
   }
 
-  void callback() {
+  void callback()
+  {
     tf_msg_.header.stamp = this->get_clock()->now();
     tf_broadcaster_->sendTransform(tf_msg_);
   }
 
- protected:
+protected:
   geometry_msgs::msg::TransformStamped tf_msg_;
   std::unique_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
   rclcpp::TimerBase::SharedPtr timer_;
-
 };
 
-#endif // PERIODIC_TRANSFORM_PUBLISHER__BROADCASTER_HPP_
+#endif  // PERIODIC_TRANSFORM_PUBLISHER__BROADCASTER_HPP_

--- a/src/periodic_transform_publisher/src/periodic_transform_publisher.cpp
+++ b/src/periodic_transform_publisher/src/periodic_transform_publisher.cpp
@@ -4,6 +4,11 @@
  * https://github.com/ros2/geometry2/blob/humble/tf2_ros/src/static_transform_broadcaster_program.cpp
  */
 
+#include "periodic_transform_publisher/broadcaster.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2/LinearMath/Vector3.h"
+
 #include <cstdio>
 #include <functional>
 #include <memory>
@@ -12,19 +17,9 @@
 #include <unordered_map>
 #include <vector>
 
-#include "tf2/LinearMath/Quaternion.h"
-#include "tf2/LinearMath/Vector3.h"
-
-#include "rclcpp/rclcpp.hpp"
-
-#include "periodic_transform_publisher/broadcaster.hpp"
-
 struct Option
 {
-  explicit Option(bool has_arg)
-  : has_argument(has_arg)
-  {
-  }
+  explicit Option(bool has_arg) : has_argument(has_arg) {}
 
   bool has_argument{false};
 
@@ -36,8 +31,7 @@ struct Option
 struct DoubleOption final : Option
 {
   explicit DoubleOption(bool has_arg, std::function<void(double)> cb)
-  : Option(has_arg),
-    callback(cb)
+  : Option(has_arg), callback(cb)
   {
   }
 
@@ -61,8 +55,7 @@ struct DoubleOption final : Option
 struct StringOption final : Option
 {
   explicit StringOption(bool has_arg, std::function<void(const std::string &)> cb)
-  : Option(has_arg),
-    callback(cb)
+  : Option(has_arg), callback(cb)
   {
   }
 
@@ -77,12 +70,8 @@ struct StringOption final : Option
 };
 
 static std::string parse_args(
-  const std::vector<std::string> & args,
-  bool & help,
-  tf2::Quaternion & quat,
-  tf2::Vector3 & trans,
-  std::string & frame_id,
-  std::string & child_frame_id)
+  const std::vector<std::string> & args, bool & help, tf2::Quaternion & quat, tf2::Vector3 & trans,
+  std::string & frame_id, std::string & child_frame_id)
 {
   size_t size = args.size();
 
@@ -102,68 +91,58 @@ static std::string parse_args(
   double pitch = 0.0;
   double yaw = 0.0;
 
-  auto qx_opt = std::make_shared<DoubleOption>(
-    true, [&quat, &saw_quat_flag](double value) {
-      quat.setX(value);
-      saw_quat_flag = true;
-    });
+  auto qx_opt = std::make_shared<DoubleOption>(true, [&quat, &saw_quat_flag](double value) {
+    quat.setX(value);
+    saw_quat_flag = true;
+  });
 
-  auto qy_opt = std::make_shared<DoubleOption>(
-    true, [&quat, &saw_quat_flag](double value) {
-      quat.setY(value);
-      saw_quat_flag = true;
-    });
+  auto qy_opt = std::make_shared<DoubleOption>(true, [&quat, &saw_quat_flag](double value) {
+    quat.setY(value);
+    saw_quat_flag = true;
+  });
 
-  auto qz_opt = std::make_shared<DoubleOption>(
-    true, [&quat, &saw_quat_flag](double value) {
-      quat.setZ(value);
-      saw_quat_flag = true;
-    });
+  auto qz_opt = std::make_shared<DoubleOption>(true, [&quat, &saw_quat_flag](double value) {
+    quat.setZ(value);
+    saw_quat_flag = true;
+  });
 
-  auto qw_opt = std::make_shared<DoubleOption>(
-    true, [&quat, &saw_quat_flag](double value) {
-      quat.setW(value);
-      saw_quat_flag = true;
-    });
+  auto qw_opt = std::make_shared<DoubleOption>(true, [&quat, &saw_quat_flag](double value) {
+    quat.setW(value);
+    saw_quat_flag = true;
+  });
 
-  auto roll_opt = std::make_shared<DoubleOption>(
-    true, [&roll, &saw_rpy_flag](double value) {
-      roll = value;
-      saw_rpy_flag = true;
-    });
+  auto roll_opt = std::make_shared<DoubleOption>(true, [&roll, &saw_rpy_flag](double value) {
+    roll = value;
+    saw_rpy_flag = true;
+  });
 
-  auto pitch_opt = std::make_shared<DoubleOption>(
-    true, [&pitch, &saw_rpy_flag](double value) {
-      pitch = value;
-      saw_rpy_flag = true;
-    });
+  auto pitch_opt = std::make_shared<DoubleOption>(true, [&pitch, &saw_rpy_flag](double value) {
+    pitch = value;
+    saw_rpy_flag = true;
+  });
 
-  auto yaw_opt = std::make_shared<DoubleOption>(
-    true, [&yaw, &saw_rpy_flag](double value) {
-      yaw = value;
-      saw_rpy_flag = true;
-    });
+  auto yaw_opt = std::make_shared<DoubleOption>(true, [&yaw, &saw_rpy_flag](double value) {
+    yaw = value;
+    saw_rpy_flag = true;
+  });
 
-  auto trans_x_opt = std::make_shared<DoubleOption>(
-    true, [&trans, &saw_trans_flag](double value) {
-      trans.setX(value);
-      saw_trans_flag = true;
-    });
+  auto trans_x_opt = std::make_shared<DoubleOption>(true, [&trans, &saw_trans_flag](double value) {
+    trans.setX(value);
+    saw_trans_flag = true;
+  });
 
-  auto trans_y_opt = std::make_shared<DoubleOption>(
-    true, [&trans, &saw_trans_flag](double value) {
-      trans.setY(value);
-      saw_trans_flag = true;
-    });
+  auto trans_y_opt = std::make_shared<DoubleOption>(true, [&trans, &saw_trans_flag](double value) {
+    trans.setY(value);
+    saw_trans_flag = true;
+  });
 
-  auto trans_z_opt = std::make_shared<DoubleOption>(
-    true, [&trans, &saw_trans_flag](double value) {
-      trans.setZ(value);
-      saw_trans_flag = true;
-    });
+  auto trans_z_opt = std::make_shared<DoubleOption>(true, [&trans, &saw_trans_flag](double value) {
+    trans.setZ(value);
+    saw_trans_flag = true;
+  });
 
-  auto frame_id_opt = std::make_shared<StringOption>(
-    true, [&frame_id, &saw_frame_flag](const std::string & value) {
+  auto frame_id_opt =
+    std::make_shared<StringOption>(true, [&frame_id, &saw_frame_flag](const std::string & value) {
       frame_id = value;
       saw_frame_flag = true;
     });
@@ -174,11 +153,10 @@ static std::string parse_args(
       saw_frame_flag = true;
     });
 
-  auto help_opt = std::make_shared<StringOption>(
-    false, [&help](const std::string & value) {
-      (void)value;
-      help = true;
-    });
+  auto help_opt = std::make_shared<StringOption>(false, [&help](const std::string & value) {
+    (void)value;
+    help = true;
+  });
 
   std::unordered_map<std::string, std::shared_ptr<Option>> options = {
     {"--qx", qx_opt},
@@ -310,7 +288,8 @@ static void print_usage()
     "usage: periodic_transform_publisher [--x X] [--y Y] [--z Z] [--qx QX] [--qy QY] "
     "[--qz QZ] [--qw QW] [--roll ROLL] [--pitch PITCH] [--yaw YAW] --frame-id FRAME_ID "
     "--child-frame-id CHILD_FRAME_ID\n\n"
-    "A command line utility for manually sending a static transform periodically.\n\nIf no translation or"
+    "A command line utility for manually sending a static transform periodically.\n\nIf no "
+    "translation or"
     " orientation is provided, the identity transform will be published.\n\nThe translation offsets"
     " are in meters.\n\nThe rotation may be provided with roll, pitch, yaw euler angles in radians,"
     " or as a quaternion.\n\n"
@@ -354,8 +333,7 @@ int main(int argc, char ** argv)
 
   rclcpp::NodeOptions options;
   // override default parameters with the desired transform
-  options.parameter_overrides(
-  {
+  options.parameter_overrides({
     {"translation.x", translation.x()},
     {"translation.y", translation.y()},
     {"translation.z", translation.z()},
@@ -375,9 +353,8 @@ int main(int argc, char ** argv)
     node->get_logger(),
     "Spinning until stopped - publishing transform\ntranslation: ('%lf', '%lf', '%lf')\n"
     "rotation: ('%lf', '%lf', '%lf', '%lf')\nfrom '%s' to '%s'",
-    translation.x(), translation.y(), translation.z(),
-    rotation.x(), rotation.y(), rotation.z(), rotation.w(),
-    frame_id.c_str(), child_frame_id.c_str());
+    translation.x(), translation.y(), translation.z(), rotation.x(), rotation.y(), rotation.z(),
+    rotation.w(), frame_id.c_str(), child_frame_id.c_str());
 
   rclcpp::spin(node);
 

--- a/src/simple_point_concatenate/include/pointcloud_concatenate/offset_concatenate_pointclouds.hpp
+++ b/src/simple_point_concatenate/include/pointcloud_concatenate/offset_concatenate_pointclouds.hpp
@@ -29,11 +29,10 @@
 // ROS includes
 #include <point_cloud_msg_wrapper/point_cloud_msg_wrapper.hpp>
 
-#include <pcl/point_types.h>
-
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
+#include <pcl/point_types.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
@@ -56,8 +55,9 @@ struct PointXYZIWithIndex
   uint8_t index{0U};
   friend bool operator==(const PointXYZIWithIndex & p1, const PointXYZIWithIndex & p2) noexcept
   {
-    return float_eq<float>(p1.x, p2.x) && float_eq<float>(p1.y, p2.y) && float_eq<float>(p1.z, p2.z) &&
-           float_eq<float>(p1.intensity, p2.intensity) && p1.index == p2.index;
+    return float_eq<float>(p1.x, p2.x) && float_eq<float>(p1.y, p2.y) &&
+           float_eq<float>(p1.z, p2.z) && float_eq<float>(p1.intensity, p2.intensity) &&
+           p1.index == p2.index;
   }
 };
 
@@ -81,7 +81,8 @@ private:
   /** \brief The output PointCloud publisher. */
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_output_;
   /** \brief Delay Compensated PointCloud publisher*/
-  std::map<std::string, rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr> transformed_raw_pc_publisher_map_;
+  std::map<std::string, rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr>
+    transformed_raw_pc_publisher_map_;
 
   /** \brief The maximum number of messages that we can store in the queue. */
   int maximum_queue_size_ = 3;
@@ -116,18 +117,20 @@ private:
   int8_t get_topic_index(const std::string & topic_name) const;
   void transformPointCloud(const PointCloud2::ConstSharedPtr & in, PointCloud2::SharedPtr & out);
   void transformPointCloud(
-    const PointCloud2::ConstSharedPtr & in, PointCloud2::SharedPtr & out, const std::string & target_frame);
+    const PointCloud2::ConstSharedPtr & in, PointCloud2::SharedPtr & out,
+    const std::string & target_frame);
   void combineClouds(sensor_msgs::msg::PointCloud2::SharedPtr & concat_cloud_ptr);
   void publish();
 
   bool is_in_side_lidar_area(const float x, const float y) const;
   void convertToXYZIICloud(
-    const sensor_msgs::msg::PointCloud2::SharedPtr & input_ptr, sensor_msgs::msg::PointCloud2::SharedPtr & output_ptr,
-    const uint8_t topic_index);
+    const sensor_msgs::msg::PointCloud2::SharedPtr & input_ptr,
+    sensor_msgs::msg::PointCloud2::SharedPtr & output_ptr, const uint8_t topic_index);
   void try_merge_point_clouds(const double stamp_msec);
   bool all_points_received();
   int lookup_index(const std::vector<double> & stamp_buff, const double stamp);
-  void cloud_callback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_ptr, const std::string & topic);
+  void cloud_callback(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_ptr, const std::string & topic);
 };
 
 LIDAR_UTILS__DEFINE_FIELD_GENERATOR_FOR_MEMBER(index);

--- a/src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp
+++ b/src/simple_point_concatenate/src/pointcloud_concatenate/offset_concatenate_pointclouds.cpp
@@ -30,7 +30,8 @@
 
 namespace pointcloud_concatenate
 {
-PointCloudOffsetConcatenationComponent::PointCloudOffsetConcatenationComponent(const rclcpp::NodeOptions & node_options)
+PointCloudOffsetConcatenationComponent::PointCloudOffsetConcatenationComponent(
+  const rclcpp::NodeOptions & node_options)
 : Node("point_cloud_offset_concatenator_component", node_options)
 {
   // Set parameters
@@ -81,7 +82,8 @@ PointCloudOffsetConcatenationComponent::PointCloudOffsetConcatenationComponent(c
   {
     for (size_t i = 0; i < input_offset_msec_.size(); ++i) {
       offset_map_msec_[input_topics_[i]] = input_offset_msec_[i];
-      std::cout << "offset_map_msec_[" << input_topics_[i] << "] = " << offset_map_msec_[input_topics_[i]] << std::endl;
+      std::cout << "offset_map_msec_[" << input_topics_[i]
+                << "] = " << offset_map_msec_[input_topics_[i]] << std::endl;
     }
   }
 
@@ -99,7 +101,8 @@ PointCloudOffsetConcatenationComponent::PointCloudOffsetConcatenationComponent(c
 
   // Subscribers
   {
-    RCLCPP_INFO_STREAM(get_logger(), "Subscribing to " << input_topics_.size() << " user given topics as inputs:");
+    RCLCPP_INFO_STREAM(
+      get_logger(), "Subscribing to " << input_topics_.size() << " user given topics as inputs:");
     for (auto & input_topic : input_topics_) {
       RCLCPP_INFO_STREAM(get_logger(), " - " << input_topic);
     }
@@ -112,7 +115,8 @@ PointCloudOffsetConcatenationComponent::PointCloudOffsetConcatenationComponent(c
       points_stamp_[input_topics_[d]] = 0;
 
       std::function<void(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)> cb = std::bind(
-        &PointCloudOffsetConcatenationComponent::cloud_callback, this, std::placeholders::_1, input_topics_[d]);
+        &PointCloudOffsetConcatenationComponent::cloud_callback, this, std::placeholders::_1,
+        input_topics_[d]);
 
       filters_[d] = this->create_subscription<sensor_msgs::msg::PointCloud2>(
         input_topics_[d], rclcpp::SensorDataQoS().keep_last(maximum_queue_size_), cb);
@@ -133,19 +137,21 @@ int8_t PointCloudOffsetConcatenationComponent::get_topic_index(const std::string
 }
 
 void PointCloudOffsetConcatenationComponent::transformPointCloud(
-  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & in, sensor_msgs::msg::PointCloud2::SharedPtr & out)
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & in,
+  sensor_msgs::msg::PointCloud2::SharedPtr & out)
 {
   transformPointCloud(in, out, output_frame_);
 }
 
 void PointCloudOffsetConcatenationComponent::transformPointCloud(
-  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & in, sensor_msgs::msg::PointCloud2::SharedPtr & out,
-  const std::string & target_frame)
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & in,
+  sensor_msgs::msg::PointCloud2::SharedPtr & out, const std::string & target_frame)
 {
   if (target_frame != in->header.frame_id) {
     if (!pcl_ros::transformPointCloud(target_frame, *in, *out, *tf2_buffer_)) {
       RCLCPP_ERROR(
-        this->get_logger(), "[transformPointCloud] Error converting first input dataset from %s to %s.",
+        this->get_logger(),
+        "[transformPointCloud] Error converting first input dataset from %s to %s.",
         in->header.frame_id.c_str(), target_frame.c_str());
       return;
     }
@@ -154,11 +160,13 @@ void PointCloudOffsetConcatenationComponent::transformPointCloud(
   }
 }
 
-void PointCloudOffsetConcatenationComponent::combineClouds(sensor_msgs::msg::PointCloud2::SharedPtr & concat_cloud_ptr)
+void PointCloudOffsetConcatenationComponent::combineClouds(
+  sensor_msgs::msg::PointCloud2::SharedPtr & concat_cloud_ptr)
 {
   for (const auto & e : points_) {
     if (e.second != nullptr) {
-      sensor_msgs::msg::PointCloud2::SharedPtr transformed_cloud_ptr(new sensor_msgs::msg::PointCloud2());
+      sensor_msgs::msg::PointCloud2::SharedPtr transformed_cloud_ptr(
+        new sensor_msgs::msg::PointCloud2());
       transformPointCloud(e.second, transformed_cloud_ptr);
 
       if (concat_cloud_ptr == nullptr) {
@@ -177,7 +185,9 @@ void PointCloudOffsetConcatenationComponent::publish()
   combineClouds(concat_cloud_ptr);
 
   if (concat_cloud_ptr) {
-    RCLCPP_INFO(this->get_logger(), "Publishing a pointcloud message with %d points.\n", concat_cloud_ptr->width);
+    RCLCPP_INFO(
+      this->get_logger(), "Publishing a pointcloud message with %d points.\n",
+      concat_cloud_ptr->width);
     auto output = std::make_unique<sensor_msgs::msg::PointCloud2>(*concat_cloud_ptr);
     pub_output_->publish(std::move(output));
   } else {
@@ -185,7 +195,8 @@ void PointCloudOffsetConcatenationComponent::publish()
   }
 }
 
-bool PointCloudOffsetConcatenationComponent::is_in_side_lidar_area(const float x, const float y) const
+bool PointCloudOffsetConcatenationComponent::is_in_side_lidar_area(
+  const float x, const float y) const
 {
   if (x < 0.0) {
     return false;
@@ -201,8 +212,8 @@ bool PointCloudOffsetConcatenationComponent::is_in_side_lidar_area(const float x
 }
 
 void PointCloudOffsetConcatenationComponent::convertToXYZIICloud(
-  const sensor_msgs::msg::PointCloud2::SharedPtr & input_ptr, sensor_msgs::msg::PointCloud2::SharedPtr & output_ptr,
-  const uint8_t topic_index)
+  const sensor_msgs::msg::PointCloud2::SharedPtr & input_ptr,
+  sensor_msgs::msg::PointCloud2::SharedPtr & output_ptr, const uint8_t topic_index)
 {
   output_ptr->header = input_ptr->header;
   output_ptr->height = input_ptr->height;
@@ -211,14 +222,15 @@ void PointCloudOffsetConcatenationComponent::convertToXYZIICloud(
 
   sensor_msgs::PointCloud2Modifier output_modifier(*output_ptr);
   output_modifier.setPointCloud2Fields(
-    5, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1, sensor_msgs::msg::PointField::FLOAT32, "z", 1,
-    sensor_msgs::msg::PointField::FLOAT32, "intensity", 1, sensor_msgs::msg::PointField::FLOAT32, "index", 1,
-    sensor_msgs::msg::PointField::UINT8);
+    5, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+    "z", 1, sensor_msgs::msg::PointField::FLOAT32, "intensity", 1,
+    sensor_msgs::msg::PointField::FLOAT32, "index", 1, sensor_msgs::msg::PointField::UINT8);
 
   output_modifier.reserve(input_ptr->width);
 
   bool has_intensity = std::any_of(
-    input_ptr->fields.begin(), input_ptr->fields.end(), [](auto & field) { return field.name == "intensity"; });
+    input_ptr->fields.begin(), input_ptr->fields.end(),
+    [](auto & field) { return field.name == "intensity"; });
 
   sensor_msgs::PointCloud2Iterator<float> in_it_x(*input_ptr, "x");
   sensor_msgs::PointCloud2Iterator<float> in_it_y(*input_ptr, "y");
@@ -232,8 +244,8 @@ void PointCloudOffsetConcatenationComponent::convertToXYZIICloud(
 
   if (has_intensity) {
     sensor_msgs::PointCloud2Iterator<uint8_t> in_it_i(*input_ptr, "intensity");
-    for (; in_it_x != in_it_x.end(); ++in_it_x, ++in_it_y, ++in_it_z, ++in_it_i, ++out_it_x, ++out_it_y, ++out_it_z,
-                                     ++out_it_intensity, ++out_it_index) {
+    for (; in_it_x != in_it_x.end(); ++in_it_x, ++in_it_y, ++in_it_z, ++in_it_i, ++out_it_x,
+                                     ++out_it_y, ++out_it_z, ++out_it_intensity, ++out_it_index) {
       if (angle_limit_lidar_index_ >= 0 && topic_index == angle_limit_lidar_index_) {
         if (is_in_side_lidar_area(*in_it_x, *in_it_y)) {
           continue;
@@ -246,8 +258,8 @@ void PointCloudOffsetConcatenationComponent::convertToXYZIICloud(
       *out_it_index = topic_index;
     }
   } else {
-    for (; in_it_x != in_it_x.end();
-         ++in_it_x, ++in_it_y, ++in_it_z, ++out_it_x, ++out_it_y, ++out_it_z, ++out_it_intensity, ++out_it_index) {
+    for (; in_it_x != in_it_x.end(); ++in_it_x, ++in_it_y, ++in_it_z, ++out_it_x, ++out_it_y,
+                                     ++out_it_z, ++out_it_intensity, ++out_it_index) {
       *out_it_x = *in_it_x;
       *out_it_y = *in_it_y;
       *out_it_z = *in_it_z;
@@ -277,8 +289,10 @@ void PointCloudOffsetConcatenationComponent::try_merge_point_clouds(const double
   RCLCPP_DEBUG(this->get_logger(), "merged point cloud at %f msec", stamp_msec);
   for (const auto & topic : input_topics_) {
     RCLCPP_INFO(
-      this->get_logger(), "%s timestamp: %f", topic.c_str(), (points_stamp_[topic] - offset_map_msec_[topic]) * 1e-3);
-    points_buff_[topic].erase(points_buff_[topic].begin(), points_buff_[topic].begin() + indices[topic] + 1);
+      this->get_logger(), "%s timestamp: %f", topic.c_str(),
+      (points_stamp_[topic] - offset_map_msec_[topic]) * 1e-3);
+    points_buff_[topic].erase(
+      points_buff_[topic].begin(), points_buff_[topic].begin() + indices[topic] + 1);
     points_stamp_buff_[topic].erase(
       points_stamp_buff_[topic].begin(), points_stamp_buff_[topic].begin() + indices[topic] + 1);
   }
@@ -296,7 +310,8 @@ bool PointCloudOffsetConcatenationComponent::all_points_received()
   return true;
 }
 
-int PointCloudOffsetConcatenationComponent::lookup_index(const std::vector<double> & stamp_buff, const double stamp)
+int PointCloudOffsetConcatenationComponent::lookup_index(
+  const std::vector<double> & stamp_buff, const double stamp)
 {
   constexpr double tolerance_msec = 50.0;
   double min_offset_msec = tolerance_msec;
@@ -322,18 +337,21 @@ void PointCloudOffsetConcatenationComponent::cloud_callback(
   if (topic_index == -1) {
     return;
   }
-  sensor_msgs::msg::PointCloud2::SharedPtr transformed_in_cloud_ptr(new sensor_msgs::msg::PointCloud2());
+  sensor_msgs::msg::PointCloud2::SharedPtr transformed_in_cloud_ptr(
+    new sensor_msgs::msg::PointCloud2());
   transformPointCloud(input, transformed_in_cloud_ptr);
   if (transformed_in_cloud_ptr->width == 0) {
-    RCLCPP_WARN(this->get_logger(), "Received an empty pointcloud message from topic: %s", topic.c_str());
+    RCLCPP_WARN(
+      this->get_logger(), "Received an empty pointcloud message from topic: %s", topic.c_str());
     return;
   }
   convertToXYZIICloud(transformed_in_cloud_ptr, xyzii_input_ptr, static_cast<uint8_t>(topic_index));
 
-  auto points_stamp_msec = input_ptr->header.stamp.sec * 1e3 + input_ptr->header.stamp.nanosec / 1e6;
+  auto points_stamp_msec =
+    input_ptr->header.stamp.sec * 1e3 + input_ptr->header.stamp.nanosec / 1e6;
   RCLCPP_DEBUG(
-    get_logger(), "Received a pointcloud message from topic: %s at %f. Point num is %d", topic.c_str(),
-    points_stamp_msec, xyzii_input_ptr->width);
+    get_logger(), "Received a pointcloud message from topic: %s at %f. Point num is %d",
+    topic.c_str(), points_stamp_msec, xyzii_input_ptr->width);
 
   points_buff_[topic].push_back(xyzii_input_ptr);
   points_stamp_buff_[topic].push_back(points_stamp_msec + offset_map_msec_[topic]);


### PR DESCRIPTION
## Summary
This PR adds clang-format to pre-commit hooks to ensure consistent C++ code formatting across the codebase.

## Changes
- Add clang-format hook to `.pre-commit-config.yaml`
- Use clang-format v18.1.5
- Configure to format C++, C, and CUDA files
- Exclude build/, install/, log/ directories
- Exclude binary files and json.hpp files
- Apply clang-format formatting to existing C++ source files

## Motivation
- Ensure consistent code style across the codebase
- Automatically format C++ code on commit
- Reduce code review time spent on formatting issues
- Align with ROS 2 coding standards (Google style with custom modifications)

## Impact
- All C++ files will be automatically formatted on commit
- Existing files have been reformatted to match the style
- No breaking changes to functionality

## Testing
- Build has been verified to succeed with the formatted code