### PR TITLE
fix(pre-commit): fix clang-format configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,13 +54,6 @@ repos:
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]
-        exclude: |
-          (?x)^(
-            build/|
-            install/|
-            log/|
-            .*\.(mcap|db3|pcd|bag|bin|so|a|o|dylib|dll|exe)|
-            .*/json\.hpp$|
-          )
+        exclude: ^(build/|install/|log/|.*\.(mcap|db3|pcd|bag|bin|so|a|o|dylib|dll|exe)|.*/json\.hpp$)
 
 exclude: .svg


### PR DESCRIPTION
## Summary
This PR fixes the clang-format pre-commit hook configuration to correctly process C++ files.

## Changes
- Fix exclude pattern format by removing `(?x)` flag that was causing "no files to check" issue
- Change exclude pattern from multi-line format to single-line format
- Verified that `pre-commit run clang-format --all-files` now works correctly

## Verification
- Confirmed v18.1.5 source code uses `types_or` correctly
- Tested with `pre-commit run clang-format --all-files` - passes successfully
- Exclude pattern correctly excludes build/, install/, log/ directories and binary files