### PR TITLE
chore(pre-commit): remove check-toml hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
     hooks:
       - id: check-json
       - id: check-merge-conflict
-      - id: check-toml
       - id: check-xml
       - id: check-yaml
       - id: detect-private-key


### PR DESCRIPTION
## Summary
Remove the check-toml pre-commit hook as there are no TOML files in the repository.

## Changes
- Remove `check-toml` hook from `.pre-commit-config.yaml`

## Verification
- Confirmed no `.toml` files exist in the repository
- Pre-commit hooks still work correctly without the check-toml hook