### PR TITLE
feat(ansible): add camera configuration flexibility and improve DTB overlay application

### DIFF
--- a/ansible/inventory/group_vars/all.yaml
+++ b/ansible/inventory/group_vars/all.yaml
@@ -14,6 +14,10 @@ has_raspi_controller: false
 has_vehicle_can: false
 has_dashboard_service: false
 lidar_driver_type: nebula
+# This option specifies the camera configuration used.
+# If using both C3 and C2 cameras: "-4 C3 -4 C2"
+# If using only C2 cameras: "-8 C2"
+make_overlay_dts_anvil_option: -4 C3 -4 C2
 
 # ROS 2 Configuration
 ros_domain_id: 1

--- a/ansible/inventory/group_vars/all.yaml
+++ b/ansible/inventory/group_vars/all.yaml
@@ -17,7 +17,7 @@ lidar_driver_type: nebula
 # This option specifies the camera configuration used.
 # If using both C3 and C2 cameras: "-4 C3 -4 C2"
 # If using only C2 cameras: "-8 C2"
-make_overlay_dts_anvil_option: -4 C3 -4 C2
+make_overlay_dts_anvil_option: "-4 C3 -4 C2" # yamllint disable-line rule:quoted-strings
 
 # ROS 2 Configuration
 ros_domain_id: 1

--- a/ansible/roles/tier4_hdr_camera_driver/tasks/main.yaml
+++ b/ansible/roles/tier4_hdr_camera_driver/tasks/main.yaml
@@ -55,8 +55,8 @@
       ansible.builtin.command: fdtoverlay -o /boot/kernel_tegra234-orin-agx-cti-AGX201-user-custom.dtb -i /boot/dtb/kernel_tegra234-orin-agx-cti-AGX201.dtb /boot/tier4-camera-device-tree-overlay-anvil.dtbo
       args:
         chdir: /boot/
-        creates: /boot/kernel_tegra234-orin-agx-cti-AGX201-user-custom.dtb
       become: true
+      changed_when: true
 
     - name: Backup extlinux.conf
       ansible.builtin.copy:


### PR DESCRIPTION
## Summary
This Pull Request introduces flexibility in camera configuration for the DRS system. It allows users to define camera setups (e.g., C3, C2, or both) via Ansible variables, which are then used to generate and apply the appropriate Device Tree Blob (DTB) overlay.

## Changes
### 🛠 Ansible Configurations
- **`ansible/inventory/group_vars/all.yaml`**: Added `make_overlay_dts_anvil_option` variable to control the camera configuration passed to the DTS generator. The default is set to `-4 C3 -4 C2`.
- **`ansible/roles/tier4_hdr_camera_driver/tasks/main.yaml`**: 
    - Improved the "Apply device tree overlay" task by removing the `creates` condition and adding `changed_when: true`. This ensures that any changes to the camera configuration are always reflected in the applied DTB overlay.

## Motivation
Previously, the camera configuration was less accessible. As we support more diverse camera setups (C2-only, C3+C2, etc.), it's essential to have a centralized and flexible way to manage these configurations through Ansible variables.

## Verification
### Manual Verification
1. Modified `make_overlay_dts_anvil_option` in `all.yaml`.
2. Verified that the `./drs-setup.sh --tags tier4_hdr_camera_driver` command is executed with the correct arguments.
3. Confirmed that `fdtoverlay` is executed correctly to update the custom DTB.
