### PR TITLE
fix: improve ansible installation logic and update galaxy install flag

### DIFF
--- a/ansible/drs-setup.sh
+++ b/ansible/drs-setup.sh
@@ -51,7 +51,15 @@ fi
 # Check if ansible is installed, if not, install it with pipx
 if ! command -v ansible-playbook &>/dev/null; then
     echo "Ansible not found. Installing ansible with pipx..."
-    pipx install --force --include-deps ansible-core
+    # Check if pipx thinks ansible-core is already installed
+    if pipx list --short | grep -q "^ansible-core "; then
+        echo "Ansible seems to be installed via pipx but command is missing."
+        echo "Attempting to reinstall/repair..."
+        pipx reinstall ansible-core
+    else
+        # Clean install
+        pipx install --include-deps ansible-core
+    fi
 
     # Verify installation
     if ! command -v ansible-playbook &>/dev/null; then
@@ -66,7 +74,7 @@ fi
 # Install Ansible Galaxy requirements
 echo "Installing Ansible Galaxy requirements..."
 if [[ -f requirements.yml ]]; then
-    ansible-galaxy collection install -r requirements.yml --force
+    ansible-galaxy collection install -r requirements.yml --upgrade
     if [[ $? -eq 0 ]]; then
         echo "Ansible Galaxy requirements installed successfully."
     else


### PR DESCRIPTION
This PR improves the robustness of the Ansible installation logic in 
drs-setup.sh
 and updates the ansible-galaxy command usage.

## Changes
### Smarter Ansible Installation Detection:
Instead of blindly forcing a re-install if ansible-playbook is missing, the script now checks pipx list --short to see if ansible-core is already installed (but potentially broken or missing from PATH).
If detected as installed, it runs pipx reinstall ansible-core to repair links.
If not installed, it proceeds with a clean pipx install --include-deps ansible-core.
### Ansible Galaxy Requirement Update:
Changed the --force flag to --upgrade in the ansible-galaxy collection install command. This ensures packages are upgraded if newer versions are available, without unnecessarily forcing re-installation of everything every time.