### PR TITLE
fix(docker): add --pull always option to run scripts

### DIFF
--- a/docker/calibration/run.sh
+++ b/docker/calibration/run.sh
@@ -114,4 +114,4 @@ else
 fi
 
 # Execute Docker command
-docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" "$DOCKER_IMAGE" "${COMMAND_ARGS[@]}"
+docker run --pull always "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" "$DOCKER_IMAGE" "${COMMAND_ARGS[@]}"

--- a/docker/runtime/run.sh
+++ b/docker/runtime/run.sh
@@ -114,4 +114,4 @@ else
 fi
 
 # Execute Docker command
-docker run "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" "$DOCKER_IMAGE" "${COMMAND_ARGS[@]}"
+docker run --pull always "${BASE_DOCKER_OPTS[@]}" "${EXTRA_DOCKER_OPTS[@]}" "$DOCKER_IMAGE" "${COMMAND_ARGS[@]}"


### PR DESCRIPTION
## Description
This PR adds the `--pull always` option to the `docker run` command in both the runtime and calibration scripts.
## Motivation & Context
To ensure that the Container always runs with the latest version of the image. Without this option, `docker run` may use a locally cached image even if a newer version has been pushed to the registry, potentially leading to inconsistency or use of outdated environments.
## Changes
- Modified [docker/runtime/run.sh](cci:7://file:///home/autoware/workspace/drs-package/data_recording_system/docker/runtime/run.sh:0:0-0:0): Added `--pull always` flag.
- Modified [docker/calibration/run.sh](cci:7://file:///home/autoware/workspace/drs-package/data_recording_system/docker/calibration/run.sh:0:0-0:0): Added `--pull always` flag.
## How Has This Been Tested?
- Executed the scripts and verified that the docker client checks for and pulls the latest image before starting the container.