### PR TITLE
feat: cap colcon build parallel workers at 4

### DIFF
--- a/ansible/roles/drs/tasks/main.yaml
+++ b/ansible/roles/drs/tasks/main.yaml
@@ -60,7 +60,7 @@
     cd {{ drs_src_dir }}
     source /opt/drs/config/drs.env
     source /opt/ros/humble/setup.bash
-    colcon build --merge-install --install-base {{ drs_install_dir }} --cmake-args -DCMAKE_BUILD_TYPE={{ drs_build_type }} --packages-up-to {{ drs_packages | join(' ') }}
+    colcon build --merge-install --install-base {{ drs_install_dir }} --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE={{ drs_build_type }} --packages-up-to {{ drs_packages | join(' ') }}
   args:
     executable: /bin/bash
   changed_when: true

--- a/docker/calibration/Dockerfile
+++ b/docker/calibration/Dockerfile
@@ -58,9 +58,9 @@ RUN apt-get update && \
 # Create install directory
 RUN mkdir -p /opt/drs/install
 
-# Build DRS packages
+# Build DRS packages (parallel workers capped at 4)
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --symlink-install --install-base /opt/drs/install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to sensor_calibration_tools
+    colcon build --symlink-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to sensor_calibration_tools
 
 # Add cyclonedds.xml
 COPY docker/cyclonedds.xml /opt/drs/config/

--- a/docker/ros2_bridge/Dockerfile
+++ b/docker/ros2_bridge/Dockerfile
@@ -68,9 +68,9 @@ RUN rosdep init && \
 # Create install directory
 RUN mkdir -p /opt/drs/install
 
-# Build DRS packages
+# Build DRS packages (parallel workers capped at 4)
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --symlink-install --install-base /opt/drs/install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to ros2_bridge
+    colcon build --symlink-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to ros2_bridge
 
 # Add cyclonedds.xml
 COPY docker/cyclonedds.xml /opt/drs/config/

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -63,9 +63,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Create install directory
 RUN mkdir -p /opt/drs/install
 
-# Build DRS packages
+# Build DRS packages (parallel workers capped at 4)
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --merge-install --install-base /opt/drs/install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to drs_launch && \
+    colcon build --merge-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to drs_launch && \
     # Remove unnecessary development files before copying to runtime
     find /opt/drs/install -name "*.a" -delete && \
     find /opt/drs/install -name "*.cmake" -delete && \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-colcon build --merge-install --install-base /opt/drs/install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to drs_launch
+colcon build --merge-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to drs_launch


### PR DESCRIPTION
## Summary

Cap all `colcon build` invocations to a maximum of 4 parallel workers (`--parallel-workers 4`) across Docker builds, Ansible, and scripts. This keeps build resource usage predictable and avoids overloading machines with many cores.

## Reason

- Without a limit, colcon uses all available CPU cores, which can make builds heavy on high-core machines and cause resource contention (e.g. in CI or shared environments).
- Capping at 4 is a reasonable default for typical development and CI setups while still allowing useful parallelism.
- Behavior is now consistent everywhere DRS is built: Docker images, Ansible playbooks, and the build script.

## Changes

| Location | Change |
|----------|--------|
| **docker/calibration/Dockerfile** | Add `--parallel-workers 4` to `colcon build`; add comment "parallel workers capped at 4". |
| **docker/runtime/Dockerfile** | Add `--parallel-workers 4` to `colcon build`; add comment. |
| **docker/ros2_bridge/Dockerfile** | Add `--parallel-workers 4` to `colcon build`; add comment. |
| **ansible/roles/drs/tasks/main.yaml** | Add `--parallel-workers 4` to the DRS role's `colcon build` step. |
| **scripts/build.sh** | Add `--parallel-workers 4` to the build command. |

## Notes

- Build type, install base, and package targets are unchanged; only the parallel worker limit is added.
- README and other documentation examples were not updated in this PR; they can be aligned in a follow-up if desired.
