### PR TITLE
feat(ci): add Docker image build and push workflow

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -104,7 +104,8 @@
     "ntsdumpdir",
     "maxupdateskew",
     "rtcfile",
-    "leapsectz"
+    "leapsectz",
+    "extraheader"
   ],
   "import": ["https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"],
   "useGitignore": true

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -61,7 +61,7 @@ jobs:
           echo "=== Temp file content (masked) ==="
           sed "s|${GH_TOKEN}|***TOKEN***|g" /tmp/drs-auth.repos | grep -E "proto_recorder|drs-api"
           # Import from temp file (use --input flag instead of stdin)
-          vcs import --input /tmp/drs-auth.repos src
+          vcs import src --input /tmp/drs-auth.repos
           rm -f /tmp/drs-auth.repos
 
       - name: Log in to Container Registry

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -57,8 +57,11 @@ jobs:
           sed -e "s|https://github.com/|https://${GH_TOKEN}@github.com/|g" \
               -e "s|git@github.com:|https://${GH_TOKEN}@github.com/|g" \
               drs.repos > /tmp/drs-auth.repos
-          # Import from temp file
-          vcs import src < /tmp/drs-auth.repos
+          # Debug: Show temp file content (masked)
+          echo "=== Temp file content (masked) ==="
+          sed "s|${GH_TOKEN}|***TOKEN***|g" /tmp/drs-auth.repos | grep -E "proto_recorder|drs-api"
+          # Import from temp file (use --input flag instead of stdin)
+          vcs import --input /tmp/drs-auth.repos src
           rm -f /tmp/drs-auth.repos
 
       - name: Log in to Container Registry

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -46,9 +46,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DRS_PAT }}
         run: |
-          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
           pip install vcstool
-          vcs import src < drs.repos
+          sed -e "s|https://github.com/|https://${GH_TOKEN}@github.com/|g" \
+              -e "s|git@github.com:|https://${GH_TOKEN}@github.com/|g" \
+              drs.repos | vcs import src
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -47,22 +47,14 @@ jobs:
           GH_TOKEN: ${{ secrets.DRS_PAT }}
         run: |
           pip install vcstool
-          # Debug: Check if token is set (show length only for security)
-          echo "GH_TOKEN length: ${#GH_TOKEN}"
-          # Debug: Test direct clone of one private repo
-          echo "Testing direct clone..."
-          git clone --depth 1 "https://${GH_TOKEN}@github.com/tier4/proto_recorder.git" /tmp/test-clone && echo "Direct clone SUCCESS" || echo "Direct clone FAILED"
-          rm -rf /tmp/test-clone
-          # Transform URLs and save to temp file
-          sed -e "s|https://github.com/|https://${GH_TOKEN}@github.com/|g" \
-              -e "s|git@github.com:|https://${GH_TOKEN}@github.com/|g" \
-              drs.repos > /tmp/drs-auth.repos
-          # Debug: Show temp file content (masked)
-          echo "=== Temp file content (masked) ==="
-          sed "s|${GH_TOKEN}|***TOKEN***|g" /tmp/drs-auth.repos | grep -E "proto_recorder|drs-api"
-          # Import from temp file (use --input flag instead of stdin)
-          vcs import src --input /tmp/drs-auth.repos
-          rm -f /tmp/drs-auth.repos
+          # Configure git to use token for github.com
+          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
+          # Convert SSH URLs to HTTPS in repos file (git config will add auth)
+          sed -e "s|git@github.com:|https://github.com/|g" drs.repos > /tmp/drs-https.repos
+          # Import repositories
+          vcs import src --input /tmp/drs-https.repos
+          rm -f /tmp/drs-https.repos
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -49,14 +49,17 @@ jobs:
           pip install vcstool
           # Debug: Check if token is set (show length only for security)
           echo "GH_TOKEN length: ${#GH_TOKEN}"
-          # Debug: Show transformed URLs (with token masked)
+          # Debug: Test direct clone of one private repo
+          echo "Testing direct clone..."
+          git clone --depth 1 "https://${GH_TOKEN}@github.com/tier4/proto_recorder.git" /tmp/test-clone && echo "Direct clone SUCCESS" || echo "Direct clone FAILED"
+          rm -rf /tmp/test-clone
+          # Transform URLs and save to temp file
           sed -e "s|https://github.com/|https://${GH_TOKEN}@github.com/|g" \
               -e "s|git@github.com:|https://${GH_TOKEN}@github.com/|g" \
-              drs.repos | sed "s|${GH_TOKEN}|***TOKEN***|g"
-          # Actual import
-          sed -e "s|https://github.com/|https://${GH_TOKEN}@github.com/|g" \
-              -e "s|git@github.com:|https://${GH_TOKEN}@github.com/|g" \
-              drs.repos | vcs import src
+              drs.repos > /tmp/drs-auth.repos
+          # Import from temp file
+          vcs import src < /tmp/drs-auth.repos
+          rm -f /tmp/drs-auth.repos
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -1,0 +1,75 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - develop/**
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - develop/**
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: docker/runtime/Dockerfile
+            image: ghcr.io/tier4/pkg-drs-runtime
+            context: .
+          - dockerfile: docker/calibration/Dockerfile
+            image: ghcr.io/tier4/pkg-drs-calibration
+            context: .
+          - dockerfile: docker/ros2_bridge/Dockerfile
+            image: ghcr.io/tier4/pkg-drs-ros2-bridge
+            context: .
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            # Set latest tag for develop branch pushes
+            type=raw,value=latest,enable=${{ github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/develop/') }}
+            # Set version tag for git tags (e.g., v1.0.0 -> 1.0.0)
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            # Also keep the full tag name
+            type=ref,event=tag
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -50,6 +50,13 @@ jobs:
           # Configure git to use token for github.com
           git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
           git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
+          # Debug: show git config (masked)
+          echo "=== Git config ==="
+          git config --global --list | grep insteadOf | sed "s|${GH_TOKEN}|***|g"
+          # Debug: test if config works
+          echo "=== Testing git clone with insteadOf ==="
+          git clone --depth 1 https://github.com/tier4/proto_recorder.git /tmp/test-insteadof && echo "SUCCESS" || echo "FAILED"
+          rm -rf /tmp/test-insteadof
           # Convert SSH URLs to HTTPS in repos file (git config will add auth)
           sed -e "s|git@github.com:|https://github.com/|g" drs.repos > /tmp/drs-https.repos
           # Import repositories

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -47,7 +47,7 @@ jobs:
           GH_TOKEN: ${{ secrets.DRS_PAT }}
         run: |
           git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-          sudo apt-get update && sudo apt-get install -y python3-vcstool
+          pip install vcstool
           vcs import src < drs.repos
 
       - name: Log in to Container Registry

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -46,6 +46,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DRS_PAT }}
         run: |
+          set -euo pipefail
           pip install vcstool
           # Remove extraheader set by actions/checkout (uses GITHUB_TOKEN which
           # only has access to this repo, not external private repos)
@@ -55,6 +56,7 @@ jobs:
           git config --global --add url."https://${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
           # Convert SSH URLs to HTTPS and import
           sed -e "s|git@github.com:|https://github.com/|g" drs.repos | vcs import src
+          echo "vcs import completed successfully"
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -47,29 +47,14 @@ jobs:
           GH_TOKEN: ${{ secrets.DRS_PAT }}
         run: |
           pip install vcstool
-          # Debug: Check token
-          echo "GH_TOKEN length: ${#GH_TOKEN}"
-          if [ -z "$GH_TOKEN" ]; then
-            echo "ERROR: GH_TOKEN is empty!"
-            exit 1
-          fi
-          # Configure git to use token for github.com
-          AUTH_URL="https://${GH_TOKEN}@github.com/"
-          echo "Setting git config insteadOf..."
-          git config --global url."${AUTH_URL}".insteadOf "https://github.com/"
-          git config --global url."${AUTH_URL}".insteadOf "git@github.com:"
-          # Debug: show git config (masked)
-          echo "=== Git config (masked) ==="
-          git config --global --list | grep -i url | sed "s|${GH_TOKEN}|***TOKEN***|g"
-          # Debug: test if config works
-          echo "=== Testing git clone with insteadOf ==="
-          git clone --depth 1 https://github.com/tier4/proto_recorder.git /tmp/test-insteadof && echo "SUCCESS" || echo "FAILED"
-          rm -rf /tmp/test-insteadof
-          # Convert SSH URLs to HTTPS in repos file (git config will add auth)
-          sed -e "s|git@github.com:|https://github.com/|g" drs.repos > /tmp/drs-https.repos
-          # Import repositories
-          vcs import src --input /tmp/drs-https.repos
-          rm -f /tmp/drs-https.repos
+          # Remove extraheader set by actions/checkout (uses GITHUB_TOKEN which
+          # only has access to this repo, not external private repos)
+          git config --unset-all http.https://github.com/.extraheader || true
+          # Configure git to use PAT for github.com
+          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+          git config --global --add url."https://${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
+          # Convert SSH URLs to HTTPS and import
+          sed -e "s|git@github.com:|https://github.com/|g" drs.repos | vcs import src
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -47,6 +47,13 @@ jobs:
           GH_TOKEN: ${{ secrets.DRS_PAT }}
         run: |
           pip install vcstool
+          # Debug: Check if token is set (show length only for security)
+          echo "GH_TOKEN length: ${#GH_TOKEN}"
+          # Debug: Show transformed URLs (with token masked)
+          sed -e "s|https://github.com/|https://${GH_TOKEN}@github.com/|g" \
+              -e "s|git@github.com:|https://${GH_TOKEN}@github.com/|g" \
+              drs.repos | sed "s|${GH_TOKEN}|***TOKEN***|g"
+          # Actual import
           sed -e "s|https://github.com/|https://${GH_TOKEN}@github.com/|g" \
               -e "s|git@github.com:|https://${GH_TOKEN}@github.com/|g" \
               drs.repos | vcs import src

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - develop/**
-    tags:
-      - v*
   pull_request:
     branches:
       - develop/**
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -56,9 +56,9 @@ jobs:
           GHCR_IMAGE="${{ matrix.ghcr_image }}"
           TAGS=""
 
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            # For git tags (e.g., v1.0.0)
-            TAG_NAME="${{ github.ref_name }}"
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # For GitHub releases (e.g., v1.0.0)
+            TAG_NAME="${{ github.event.release.tag_name }}"
             # Remove 'v' prefix if present
             VERSION="${TAG_NAME#v}"
             TAGS="${GHCR_IMAGE}:${VERSION}"

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -47,12 +47,20 @@ jobs:
           GH_TOKEN: ${{ secrets.DRS_PAT }}
         run: |
           pip install vcstool
+          # Debug: Check token
+          echo "GH_TOKEN length: ${#GH_TOKEN}"
+          if [ -z "$GH_TOKEN" ]; then
+            echo "ERROR: GH_TOKEN is empty!"
+            exit 1
+          fi
           # Configure git to use token for github.com
-          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
+          AUTH_URL="https://${GH_TOKEN}@github.com/"
+          echo "Setting git config insteadOf..."
+          git config --global url."${AUTH_URL}".insteadOf "https://github.com/"
+          git config --global url."${AUTH_URL}".insteadOf "git@github.com:"
           # Debug: show git config (masked)
-          echo "=== Git config ==="
-          git config --global --list | grep insteadOf | sed "s|${GH_TOKEN}|***|g"
+          echo "=== Git config (masked) ==="
+          git config --global --list | grep -i url | sed "s|${GH_TOKEN}|***TOKEN***|g"
           # Debug: test if config works
           echo "=== Testing git clone with insteadOf ==="
           git clone --depth 1 https://github.com/tier4/proto_recorder.git /tmp/test-insteadof && echo "SUCCESS" || echo "FAILED"

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -27,16 +27,28 @@ jobs:
           - build_dir: docker/runtime
             local_image: tier4/pkg-drs-runtime:latest
             ghcr_image: ghcr.io/tier4/pkg-drs-runtime
+            needs_vcs_import: true
           - build_dir: docker/calibration
             local_image: tier4/pkg-drs-calibration:latest
             ghcr_image: ghcr.io/tier4/pkg-drs-calibration
+            needs_vcs_import: false
           - build_dir: docker/ros2_bridge
             local_image: tier4/drs-ros2-bridge:latest
             ghcr_image: ghcr.io/tier4/pkg-drs-ros2-bridge
+            needs_vcs_import: true
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Import external repositories
+        if: matrix.needs_vcs_import
+        env:
+          GH_TOKEN: ${{ secrets.DRS_PAT }}
+        run: |
+          git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+          sudo apt-get update && sudo apt-get install -y python3-vcstool
+          vcs import src < drs.repos
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -24,22 +24,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - dockerfile: docker/runtime/Dockerfile
-            image: ghcr.io/tier4/pkg-drs-runtime
-            context: .
-          - dockerfile: docker/calibration/Dockerfile
-            image: ghcr.io/tier4/pkg-drs-calibration
-            context: .
-          - dockerfile: docker/ros2_bridge/Dockerfile
-            image: ghcr.io/tier4/pkg-drs-ros2-bridge
-            context: .
+          - build_dir: docker/runtime
+            local_image: tier4/pkg-drs-runtime:latest
+            ghcr_image: ghcr.io/tier4/pkg-drs-runtime
+          - build_dir: docker/calibration
+            local_image: tier4/pkg-drs-calibration:latest
+            ghcr_image: ghcr.io/tier4/pkg-drs-calibration
+          - build_dir: docker/ros2_bridge
+            local_image: tier4/drs-ros2-bridge:latest
+            ghcr_image: ghcr.io/tier4/pkg-drs-ros2-bridge
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
@@ -49,27 +46,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ matrix.image }}
-          tags: |
-            # Set latest tag for develop branch pushes
-            type=raw,value=latest,enable=${{ github.ref_type == 'branch' && startsWith(github.ref, 'refs/heads/develop/') }}
-            # Set version tag for git tags (e.g., v1.0.0 -> 1.0.0)
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            # Also keep the full tag name
-            type=ref,event=tag
+      - name: Build Docker image using build.sh
+        working-directory: ${{ matrix.build_dir }}
+        run: ./build.sh
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Determine image tags
+        id: tags
+        run: |
+          GHCR_IMAGE="${{ matrix.ghcr_image }}"
+          TAGS=""
+
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            # For git tags (e.g., v1.0.0)
+            TAG_NAME="${{ github.ref_name }}"
+            # Remove 'v' prefix if present
+            VERSION="${TAG_NAME#v}"
+            TAGS="${GHCR_IMAGE}:${VERSION}"
+            # Also add the full tag name
+            TAGS="${TAGS},${GHCR_IMAGE}:${TAG_NAME}"
+          else
+            # For develop branch pushes
+            TAGS="${GHCR_IMAGE}:latest"
+          fi
+
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Tag and push Docker image
+        if: github.event_name != 'pull_request'
+        run: |
+          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.tags.outputs.tags }}"
+          for TAG in "${TAG_ARRAY[@]}"; do
+            docker tag "${{ matrix.local_image }}" "${TAG}"
+            docker push "${TAG}"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ src/proto_recorder
 
 # cache
 .cache/
+
+# Private docs
+.docs/

--- a/docker/ros2_bridge/Dockerfile
+++ b/docker/ros2_bridge/Dockerfile
@@ -61,7 +61,7 @@ RUN rosdep init && \
     rosdep update && \
     apt-get update && \
     source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon list --packages-up-to ros2_bridge | awk '{print $2}' | xargs rosdep install -iry --from-paths && \
+    rosdep install -y -r --from-paths `colcon list --packages-up-to ros2_bridge -p` --ignore-src --rosdistro ${ROS_DISTRO} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/drs.repos
+++ b/drs.repos
@@ -17,7 +17,7 @@ repositories:
     version: 7081f40b32341d8d82ef00dee20b856e4283d4e9  # aeva_seyond
   dependencies/seyond_ros_driver:
     type: git
-    url: git@github.com:tier4/seyond_ros_driver.git
+    url: https://github.com/tier4/seyond_ros_driver.git
     version: 516db2d344105935b56c979b0c1b138e28b08434  # tier4/develop
     recursive: true
   dependencies/seyond_ros_driver/src/seyond_lidar_ros/src/seyond_sdk:
@@ -34,15 +34,15 @@ repositories:
     version: 022d160e13e378bdfe34e5222a0e89f3a51cf081  # feat/data_recording_system
   dependencies/c2_readout_delay_setter:
     type: git
-    url: git@github.com:tier4/c2_readout_delay_setter.git
+    url: https://github.com/tier4/c2_readout_delay_setter.git
     version: 47ed673503a4796099478e1e11646a11d2709c7d  # feat/drs
   proto_recorder:
     type: git
-    url: git@github.com:tier4/proto_recorder.git
+    url: https://github.com/tier4/proto_recorder.git
     version: 13b9c84aacf16e9d7a22915c3b929e4ddf68e6a6  # main
   drs-api:
     type: git
-    url: git@github.com:tier4/drs-api.git
+    url: https://github.com/tier4/drs-api.git
     version: 058feb116fecdaccfbdc47571ba98400be3dfe7d  # main
   bag_converter:
     type: git

--- a/drs.repos
+++ b/drs.repos
@@ -17,7 +17,7 @@ repositories:
     version: 7081f40b32341d8d82ef00dee20b856e4283d4e9  # aeva_seyond
   dependencies/seyond_ros_driver:
     type: git
-    url: https://github.com/tier4/seyond_ros_driver.git
+    url: git@github.com:tier4/seyond_ros_driver.git
     version: 516db2d344105935b56c979b0c1b138e28b08434  # tier4/develop
     recursive: true
   dependencies/seyond_ros_driver/src/seyond_lidar_ros/src/seyond_sdk:
@@ -34,15 +34,15 @@ repositories:
     version: 022d160e13e378bdfe34e5222a0e89f3a51cf081  # feat/data_recording_system
   dependencies/c2_readout_delay_setter:
     type: git
-    url: https://github.com/tier4/c2_readout_delay_setter.git
+    url: git@github.com:tier4/c2_readout_delay_setter.git
     version: 47ed673503a4796099478e1e11646a11d2709c7d  # feat/drs
   proto_recorder:
     type: git
-    url: https://github.com/tier4/proto_recorder.git
+    url: git@github.com:tier4/proto_recorder.git
     version: 13b9c84aacf16e9d7a22915c3b929e4ddf68e6a6  # main
   drs-api:
     type: git
-    url: https://github.com/tier4/drs-api.git
+    url: git@github.com:tier4/drs-api.git
     version: 058feb116fecdaccfbdc47571ba98400be3dfe7d  # main
   bag_converter:
     type: git


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow for building and pushing Docker images, with support for cloning external private repositories via `vcs import` and PAT authentication.

### Target Images

| Image | Build Directory | vcs import |
|-------|-----------------|------------|
| `ghcr.io/tier4/pkg-drs-runtime` | `docker/runtime` | ✅ Required |
| `ghcr.io/tier4/pkg-drs-calibration` | `docker/calibration` | ❌ Not required |
| `ghcr.io/tier4/pkg-drs-ros2-bridge` | `docker/ros2_bridge` | ✅ Required |

### Triggers

- Push to `develop/**` branches → Push with `latest` tag
- Pull request to `develop/**` branches → Build only (no push)
- GitHub Release published → Push with version tag

### External Repository Cloning

`runtime` and `ros2_bridge` images depend on external repositories excluded via `.gitignore`:

- `tier4/drs-api`
- `tier4/proto_recorder`
- `tier4/seyond_ros_driver`
- `tier4/c2_readout_delay_setter`

These are cloned via `vcs import` using the `DRS_PAT` secret for authentication. The workflow uses `git config url.insteadOf` to transparently rewrite URLs, consistent with the Ansible-based approach in `ansible/roles/drs/tasks/main.yaml`.

Key implementation details:
- The `http.extraheader` set by `actions/checkout` (which uses `GITHUB_TOKEN` scoped only to this repo) must be removed to avoid interfering with PAT authentication to external repos
- `git config --global --add url.insteadOf` is used to rewrite both HTTPS and SSH URLs to authenticated HTTPS
- SSH URLs in `drs.repos` are preserved for local development compatibility

### Required Setup

Add `DRS_PAT` repository secret (Settings → Secrets and variables → Actions):
```bash
gh secret set DRS_PAT
```
- Create a Classic PAT with `repo` scope, or a Fine-grained PAT with `Contents: Read-only` for the private repositories listed above
- If using a Classic PAT with an organization that uses SAML SSO, authorize the token via "Configure SSO"

### Changes

- `.github/workflows/docker-build-push.yaml`:
  - Add Docker image build and push workflow with matrix strategy
  - Add `needs_vcs_import` matrix flag for conditional external repo cloning
  - Add `vcs import` step with PAT-based authentication via `git config url.insteadOf`
  - Remove `actions/checkout` extraheader to avoid `GITHUB_TOKEN` interference
  - Use `ubuntu-22.04` runner
  - Install vcstool via pip
  - Trigger on `develop/**` push, PR, and release events
- `docker/ros2_bridge/Dockerfile`: Fix rosdep install command
- `docker/*/build.sh`: Use build.sh scripts for Docker builds
- `.cspell.json`: Add `extraheader` to spell check dictionary
- `.gitignore`: Add `.docs/` to gitignore

## Test plan

- [x] `ros2_bridge` image builds successfully
- [ ] `runtime` image builds successfully
- [ ] `calibration` image builds successfully
- [ ] Version tags are pushed correctly when a Release is created
- [ ] Local development with SSH keys still works (`vcs import src < drs.repos`)