### PR TITLE
fix: switch dependent repos to HTTPS and add --force to vcs import

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -55,7 +55,7 @@ jobs:
           git config --global url."https://${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
           git config --global --add url."https://${GH_TOKEN}@github.com/".insteadOf "git@github.com:"
           # Convert SSH URLs to HTTPS and import
-          sed -e "s|git@github.com:|https://github.com/|g" drs.repos | vcs import src
+          sed -e "s|git@github.com:|https://github.com/|g" drs.repos | vcs import --force src
           echo "vcs import completed successfully"
 
       - name: Log in to Container Registry

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For detailed dependency libraries, please refer to [`docker/runtime/Dockerfile`]
 ```bash
 git clone https://github.com/tier4/data_recording_system.git
 cd data_recording_system
-vcs import src < drs.repos
+vcs import --force src < drs.repos
 rosdep install -y -r --from-paths `colcon list --packages-up-to drs_launch -p` --ignore-src
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to drs_launch
 ```

--- a/ansible/roles/drs/tasks/main.yaml
+++ b/ansible/roles/drs/tasks/main.yaml
@@ -13,9 +13,9 @@
     if [ -n "{{ github_pat }}" ]; then
       sed -e 's|https://github.com/|https://{{ github_pat }}@github.com/|g' \
           -e 's|git@github.com:|https://{{ github_pat }}@github.com/|g' \
-          drs.repos | vcs import src
+          drs.repos | vcs import --force src
     else
-      vcs import src < drs.repos
+      vcs import --force src < drs.repos
     fi
   args:
     executable: /bin/bash

--- a/docker/calibration/Dockerfile
+++ b/docker/calibration/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR /opt/drs
 
 RUN mkdir -p /opt/drs/src && \
     git clone https://github.com/tier4/CalibrationTools.git -b feat/drs_202505 /opt/drs/src/calibration_tools && \
-    vcs import src < /opt/drs/src/calibration_tools/calibration_tools_standalone.repos
+    vcs import --force src < /opt/drs/src/calibration_tools/calibration_tools_standalone.repos
 
 # Initialize and update rosdep
 RUN rosdep init && \

--- a/drs.repos
+++ b/drs.repos
@@ -17,7 +17,7 @@ repositories:
     version: 7081f40b32341d8d82ef00dee20b856e4283d4e9  # aeva_seyond
   dependencies/seyond_ros_driver:
     type: git
-    url: git@github.com:tier4/seyond_ros_driver.git
+    url: https://github.com/tier4/seyond_ros_driver.git
     version: 516db2d344105935b56c979b0c1b138e28b08434  # tier4/develop
     recursive: true
   dependencies/seyond_ros_driver/src/seyond_lidar_ros/src/seyond_sdk:
@@ -38,11 +38,11 @@ repositories:
     version: 47ed673503a4796099478e1e11646a11d2709c7d  # feat/drs
   proto_recorder:
     type: git
-    url: git@github.com:tier4/proto_recorder.git
+    url: https://github.com/tier4/proto_recorder.git
     version: 13b9c84aacf16e9d7a22915c3b929e4ddf68e6a6  # main
   drs-api:
     type: git
-    url: git@github.com:tier4/drs-api.git
+    url: https://github.com/tier4/drs-api.git
     version: 058feb116fecdaccfbdc47571ba98400be3dfe7d  # main
   bag_converter:
     type: git


### PR DESCRIPTION
## Summary

- **Switch SSH URLs to HTTPS** for 3 dependent repositories (`seyond_ros_driver`, `proto_recorder`, `drs-api`) in `drs.repos`, as these repositories have been changed to public and no longer require SSH access.
- **Add `--force` flag to all `vcs import` invocations** to prevent errors that occur when re-importing repositories whose visibility has changed (e.g., from private/SSH to public/HTTPS).

## Changes

### `drs.repos`
- `seyond_ros_driver`: `git@github.com:tier4/seyond_ros_driver.git` → `https://github.com/tier4/seyond_ros_driver.git`
- `proto_recorder`: `git@github.com:tier4/proto_recorder.git` → `https://github.com/tier4/proto_recorder.git`
- `drs-api`: `git@github.com:tier4/drs-api.git` → `https://github.com/tier4/drs-api.git`

### `vcs import --force` (all occurrences)
- `.github/workflows/docker-build-push.yaml` — CI workflow
- `README.md` — local build instructions
- `ansible/roles/drs/tasks/main.yaml` — Ansible provisioning (both PAT and non-PAT paths)
- `docker/calibration/Dockerfile` — calibration Docker image build

## Why

The dependent repositories (`seyond_ros_driver`, `proto_recorder`, `drs-api`) have been changed to public. This means:

1. **SSH URLs are no longer necessary** — HTTPS access works without requiring SSH keys, which simplifies CI and local setup.
2. **`vcs import` can fail without `--force`** — In environments where these repositories were previously cloned via SSH URL (`git@github.com:...`) when they were private, running `vcs import` with the new HTTPS URL (`https://github.com/...`) causes it to compare the remote URLs and determine that a different repository already exists at the same path, resulting in an import error. The `--force` flag causes `vcs import` to delete the existing directory and re-clone, avoiding this error caused by the SSH-to-HTTPS URL change.

## Test plan

- [ ] Verify CI Docker build workflow completes successfully
- [ ] Verify local `vcs import --force src < drs.repos` works without SSH keys
- [ ] Verify Ansible provisioning imports repositories correctly
- [ ] Verify calibration Docker image builds successfully