### PR TITLE
fix(ci): restrict Docker push triggers and simplify release tags

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -3,10 +3,10 @@ name: Build and Push Docker Images
 on:
   push:
     branches:
-      - develop/**
+      - develop/r36.4.0
   pull_request:
     branches:
-      - develop/**
+      - develop/r36.4.0
   release:
     types: [published]
 
@@ -79,13 +79,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "release" ]]; then
             # For GitHub releases (e.g., v1.0.0)
             TAG_NAME="${{ github.event.release.tag_name }}"
-            # Remove 'v' prefix if present
-            VERSION="${TAG_NAME#v}"
-            TAGS="${GHCR_IMAGE}:${VERSION}"
-            # Also add the full tag name
-            TAGS="${TAGS},${GHCR_IMAGE}:${TAG_NAME}"
+            TAGS="${GHCR_IMAGE}:${TAG_NAME}"
           else
-            # For develop branch pushes
+            # For pushes to main branch
             TAGS="${GHCR_IMAGE}:latest"
           fi
 


### PR DESCRIPTION
## Summary
- Narrow push/PR triggers from `develop/**` to `develop/r36.4.0` so that `latest`-tagged images are only built and pushed on main branch updates (not on every develop sub-branch push)
- Remove redundant version tag without `v` prefix on release events; only the original tag name (e.g., `v0.1.9`) is pushed to GHCR

## Trigger behavior after this change
| Event | Build | Push to GHCR | Tag |
|---|---|---|---|
| Push to `develop/r36.4.0` | Yes | Yes | `latest` |
| PR targeting `develop/r36.4.0` | Yes | No | — |
| Release published | Yes | Yes | `<tag_name>` (e.g., `v0.1.9`) |

## Test plan
- [ ] Verify workflow triggers on push to `develop/r36.4.0`
- [ ] Verify workflow does NOT trigger on push to other `develop/*` branches
- [ ] Verify release publish pushes image with tag name only (no extra versionless tag)