### PR TITLE
fix: improve PTP stability by initializing from NTP once

### DIFF
--- a/ansible/inventory/host_vars/ecu0.yaml
+++ b/ansible/inventory/host_vars/ecu0.yaml
@@ -19,8 +19,8 @@ ptp:
   ntp_server: ntp.nict.jp
   master_port: mgbe0
   slave_ports:
-    - eqos0
     - enP1p1s0
+    - eqos0
   clock_class: 187
   priority1: 128
   priority2: 128

--- a/ansible/roles/ptp/templates/phc2sys.sh.ntp.j2
+++ b/ansible/roles/ptp/templates/phc2sys.sh.ntp.j2
@@ -12,10 +12,18 @@ chronyd -q -t 15 -n 'server {{ ptp.ntp_server }} iburst'
 /usr/sbin/phc_ctl {{ port }} set
 {% endfor %}
 
-# Synchronize PHCs with system clock (NTP-synchronized system time)
+# Synchronize PHCs with system clock (NTP-synchronized system time) only once
 # System time (CLOCK_REALTIME) is the source, PHCs are the targets
 {% for port in ptp.slave_ports %}
-/usr/sbin/phc2sys -s CLOCK_REALTIME -c {{ port }} -w -m --step_threshold=1 &
+/usr/sbin/phc2sys -s CLOCK_REALTIME -c {{ port }} -w -O 0
+{% endfor %}
+
+# Synchronize System Clock and other PHCs from the first PHC (Master) periodically
+/usr/sbin/phc2sys -s {{ ptp.slave_ports[0] }} -c CLOCK_REALTIME -w -m --step_threshold=1 &
+{% for port in ptp.slave_ports %}
+{% if not loop.first %}
+/usr/sbin/phc2sys -s {{ ptp.slave_ports[0] }} -c {{ port }} -w -m --step_threshold=1 &
+{% endif %}
 {% endfor %}
 
 # Wait for all background processes

--- a/ansible/roles/ptp/templates/ptp4l.conf.j2
+++ b/ansible/roles/ptp/templates/ptp4l.conf.j2
@@ -16,6 +16,7 @@ network_transport       UDPv4
 twoStepFlag             1
 
 logSyncInterval         -3
+logMinDelayReqInterval  -3
 
 # Master port
 [{{ ptp.master_port }}]

--- a/ansible/roles/ptp/templates/ptp4l.conf.j2
+++ b/ansible/roles/ptp/templates/ptp4l.conf.j2
@@ -15,6 +15,8 @@ delay_mechanism         E2E
 network_transport       UDPv4
 twoStepFlag             1
 
+logSyncInterval         -3
+
 # Master port
 [{{ ptp.master_port }}]
 

--- a/ansible/roles/ptp/templates/ptp4l.conf.ntp.j2
+++ b/ansible/roles/ptp/templates/ptp4l.conf.ntp.j2
@@ -15,6 +15,8 @@ delay_mechanism         E2E
 network_transport       UDPv4
 twoStepFlag             1
 
+logSyncInterval         -3
+
 # Slave ports
 {% for port in ptp.slave_ports %}
 [{{ port }}]

--- a/ansible/roles/ptp/templates/ptp4l.conf.ntp.j2
+++ b/ansible/roles/ptp/templates/ptp4l.conf.ntp.j2
@@ -16,6 +16,7 @@ network_transport       UDPv4
 twoStepFlag             1
 
 logSyncInterval         -3
+logMinDelayReqInterval  -3
 
 # Slave ports
 {% for port in ptp.slave_ports %}


### PR DESCRIPTION
## Description
This PR addresses stability issues when performing PTP time synchronization based on a system time updated via NTP.

The main changes are:
1. **One-Time NTP Synchronization**: Modified `phc2sys` to synchronize the PTP Hardware Clock (PHC) from the System Clock (NTP) only once at startup (using the `-O 0` flag). This initializes the absolute time without introducing continuous jitter from the NTP loop.
2. **PTP-Driven Synchronization**: After the initial NTP update, the synchronization topology is inverted to rely on the PTP hardware clock as the master time source.
    * The System Clock (`CLOCK_REALTIME`) is subsequently synchronized *from* the first slave port (`enP1p1s0`).
    * Other PHCs (e.g., `eqos0`) are synchronized *from* the first slave port (`enP1p1s0`).
3. **Configuration Updates**:
    * Reordered `slave_ports` in `ecu0.yaml` to prioritize `enP1p1s0` as the primary reference.
    * Updated `ptp4l` configuration to set `logSyncInterval` to `-3` (8 messages/s) for tighter synchronization.

## Motivation
Updating the hardware clock continuously from NTP was found to cause instability in the PTP domain. By performing a one-time synchronization at startup and then letting the high-precision PTP clock drive the system time, we achieve a more stable synchronization state.
