### PR TITLE
chore: rewrite root .gitignore with comprehensive patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,66 @@
+# ── OS-specific ───────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ── Editor / IDE ─────────────────────────────────────────────
 # Vim
 *.swp
 *.swo
-
-# Visual Studio Code
+*~
+# VSCode
 .vscode/
 *.code-workspace
+# Cursor
 .cursor/
+# Windsurf
+.windsurf/
+# Antigravity (Google)
+.agent/
+# JetBrains
+.idea/
 
-# colcon
+# ── C/C++ build artifacts ────────────────────────────────────
+*.o
+*.a
+*.so
+*.dylib
+*.dll
+*.exe
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles/
+
+# ── Python ───────────────────────────────────────────────────
+*.pyc
+__pycache__/
+*.py[cod]
+*$py.class
+
+# ── ROS 2 / colcon ──────────────────────────────────────────
 build/
 install/
 log/
 /src/dependencies
+.colcon*
+# rosbag files (all storage backends)
+*.bag
+*.db3
+*.mcap
 
-# Python
-*.pyc
+# ── IDE / language server ────────────────────────────────────
+.clangd/
+compile_commands.json
 
-# Jetbrains
-.idea/
+# ── Cache ────────────────────────────────────────────────────
+.cache/
 
-# External repositories
+# ── External repositories (managed via vcs import) ──────────
 src/bag_converter/
 src/drs-api/
 src/proto_recorder
 
-# Ansible temporary directories
+# ── Ansible ──────────────────────────────────────────────────
 .ansible/
 
-# cache
-.cache/
-
-# Private docs
+# ── Private docs ─────────────────────────────────────────────
 .docs/


### PR DESCRIPTION
## Summary
- Reorganize `.gitignore` into clearly labeled sections for better readability
- Add missing ignore patterns: OS artifacts, C/C++ build outputs, Python bytecode, rosbag files (`.bag`, `.db3`, `.mcap`), colcon config, language server artifacts, and additional IDE directories (Windsurf, Antigravity)
- All existing patterns are preserved; no previously tracked files are affected

## Test plan
- [x] `git status` confirms only `.gitignore` is modified
- [x] `git check-ignore` verified all vcs-import packages are still ignored
- [x] `git check-ignore` verified all new patterns match expected paths
- [x] `git ls-files -i --exclude-standard` returns empty (no tracked files newly ignored)
- [x] All pre-commit hooks pass