### PR TITLE
chore: add .dockerignore to reduce Docker build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,76 @@
+# ── Git ───────────────────────────────────────────────────────
+.git/
+.github/
+.gitignore
+
+# ── ROS 2 / colcon build artifacts ───────────────────────────
+build/
+install/
+log/
+.colcon*
+
+# ── Documentation ────────────────────────────────────────────
+docs/
+.docs/
+README.md
+CLAUDE.md
+LICENSE
+
+# ── Ansible ──────────────────────────────────────────────────
+ansible/
+.ansible/
+.ansible-lint
+
+# ── CI / linter configs ─────────────────────────────────────
+.pre-commit-config*.yaml
+.cspell.json
+.hadolint.yaml
+.markdownlint.yaml
+.markdown-link-check.json
+.prettierrc.yaml
+.shellcheckrc
+.yamllint.yaml
+.clang-format
+CPPLINT.cfg
+setup.cfg
+
+# ── IDE / editor ─────────────────────────────────────────────
+.vscode/
+.cursor/
+.windsurf/
+.idea/
+.agent/
+.claude/
+*.code-workspace
+*.swp
+*.swo
+*~
+
+# ── OS-specific ──────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ── Caches ───────────────────────────────────────────────────
+.cache/
+.clangd/
+compile_commands.json
+
+# ── C/C++ build artifacts ───────────────────────────────────
+*.o
+*.a
+*.so
+*.dylib
+
+# ── Python artifacts ────────────────────────────────────────
+*.pyc
+__pycache__/
+*.py[cod]
+*$py.class
+
+# ── ROS bag files ───────────────────────────────────────────
+*.bag
+*.db3
+*.mcap
+
+# ── Scripts (not used in Docker builds) ─────────────────────
+scripts/


### PR DESCRIPTION
## Summary

- Add a `.dockerignore` file at the repository root to exclude files not needed by any Dockerfile
- All three Docker builds (`runtime`, `calibration`, `ros2_bridge`) use the repo root as build context, sending ~520MB to the Docker daemon — only `src/` and `docker/` are actually referenced in `COPY` instructions
- Excludes `build/`, `install/`, `log/`, `docs/`, `ansible/`, `.github/`, IDE/editor files, linter configs, C/C++/Python artifacts, and rosbag files (~265MB+ reduction)

## How to verify

1. Run any of the Docker builds and confirm the build context sent to the daemon is significantly smaller:
   ```bash
   docker/runtime/build.sh
   ```
   Look for the "Sending build context to Docker daemon" line — it should be much smaller than before.

2. Verify the built image still works correctly (all `COPY` instructions succeed and the container starts).

## Improvements

- Faster Docker builds locally and in CI (less data transferred to the daemon)
- Reduces CI job time for the `docker-build-push` workflow

## Limitations

- If a new Dockerfile is added that needs files currently excluded (e.g., `scripts/`), the `.dockerignore` will need to be updated accordingly