### PR TITLE
fix: remove redundant role dependencies in meta settings

### DIFF
--- a/ansible/roles/anvil_docker/meta/main.yaml
+++ b/ansible/roles/anvil_docker/meta/main.yaml
@@ -1,2 +1,0 @@
-dependencies:
-  - ssd_mount

--- a/ansible/roles/drs/meta/main.yaml
+++ b/ansible/roles/drs/meta/main.yaml
@@ -1,3 +1,0 @@
-allow_duplicates: false
-dependencies:
-  - role: ros2

--- a/ansible/roles/drs_recorder_service/meta/main.yaml
+++ b/ansible/roles/drs_recorder_service/meta/main.yaml
@@ -1,3 +1,0 @@
-dependencies:
-  - role: drs_config
-  - role: drs

--- a/ansible/roles/drs_ros2_bridge_service/meta/main.yaml
+++ b/ansible/roles/drs_ros2_bridge_service/meta/main.yaml
@@ -1,2 +1,0 @@
-dependencies:
-  - role: cyclonedds

--- a/ansible/roles/drs_sensor_service/meta/main.yaml
+++ b/ansible/roles/drs_sensor_service/meta/main.yaml
@@ -1,3 +1,0 @@
-dependencies:
-  - role: drs
-  - role: drs_config


### PR DESCRIPTION
## Description
This PR removes the `meta/main.yaml` files from several Ansible roles (`anvil_docker`, `drs`, `drs_recorder_service`, `drs_ros2_bridge_service`, `drs_sensor_service`). 
These files previously defined dependencies that caused roles to be executed multiple times redundantly and in an unintended order. By removing these meta-dependencies, we ensure that roles are executed only when explicitly called in the playbooks, improving deployment stability and performance.
## Tests performed
- Manually verified that the targeted `meta/main.yaml` files are deleted from the repository.
- Checked that the working tree is clean and the changes are correctly committed and pushed.
## Effects on system behavior
- Prevents redundant execution of Ansible roles during deployment.
- Ensures a more predictable execution order for roles as defined in top-level playbooks.
