### PR TITLE
feat: update drs-api to develop and enable multi-disk monitoring

### DIFF
--- a/ansible/roles/drs_api_service/files/module-manager-ecu0.yaml
+++ b/ansible/roles/drs_api_service/files/module-manager-ecu0.yaml
@@ -3,7 +3,13 @@ server:
 
 disk:
   enabled: true
-  monitor_path: /mnt/ssd/data
+  disks:
+    - name: internal
+      mount_path: /mnt/ssd/data
+      description: Internal SSD
+    - name: external
+      mount_path: /mnt/external/data
+      description: External SSD
 
 services:
   enabled: true

--- a/ansible/roles/drs_api_service/files/module-manager-ecu1.yaml
+++ b/ansible/roles/drs_api_service/files/module-manager-ecu1.yaml
@@ -3,7 +3,13 @@ server:
 
 disk:
   enabled: true
-  monitor_path: /mnt/ssd/data
+  disks:
+    - name: internal
+      mount_path: /mnt/ssd/data
+      description: Internal SSD
+    - name: external
+      mount_path: /mnt/external/data
+      description: External SSD
 
 services:
   enabled: true

--- a/drs.repos
+++ b/drs.repos
@@ -43,7 +43,7 @@ repositories:
   drs-api:
     type: git
     url: https://github.com/tier4/drs-api.git
-    version: 058feb116fecdaccfbdc47571ba98400be3dfe7d  # main
+    version: a1f6884a2db8545d36ca2885444affe3c510b384  # develop
   bag_converter:
     type: git
     url: https://github.com/tier4/bag_converter.git


### PR DESCRIPTION
## Summary
Update `drs-api` to the latest version and migrate module-manager configuration to support multi-disk monitoring for both ECU0 and ECU1.

## Changes

### 1. Update `drs-api` version (drs.repos)
- Updated `drs-api` from `main` (`058feb1`) to `develop` (`a1f6884`) to incorporate multi-disk monitoring support.

> **⚠️ Note:** This change switches the `drs-api` reference from the `main` branch to the `develop` branch. Please confirm whether targeting `develop` is acceptable, or if we should wait until the relevant changes are merged into `main` and update the commit hash accordingly.

-> Confirmed that this is okay.

### 2. Enable multi-disk monitoring (module-manager-ecu0.yaml, module-manager-ecu1.yaml)
- Replaced the single `monitor_path` field with a `disks` list to support monitoring multiple disks simultaneously.
- Configured two disks per ECU:
  - **internal**: `/mnt/ssd/data` (Internal SSD)
  - **external**: `/mnt/external/data` (External SSD)