### PR TITLE
fix: update oxts_ros2_driver version to include bug fixes

### DIFF
--- a/drs.repos
+++ b/drs.repos
@@ -31,7 +31,7 @@ repositories:
   dependencies/oxts_ros2_driver:
     type: git
     url: https://github.com/tier4/oxts_ros2_driver.git
-    version: 022d160e13e378bdfe34e5222a0e89f3a51cf081  # feat/data_recording_system
+    version: 75648c23ca54bc860aa52d2c03848f601f51bae4  # feat/data_recording_system
   dependencies/c2_readout_delay_setter:
     type: git
     url: git@github.com:tier4/c2_readout_delay_setter.git


### PR DESCRIPTION
## Description
This PR updates the version hash for `oxts_ros2_driver` in `drs.repos` to incorporate recent bug fix.

The fixed bug involves an issue where transitioning from a "GPS unscanned" state to a "GPS scanned" state leads to a false detection of a time reverse jump. This false detection prevents the driver from correctly processing subsequent NCOM packets.

The version is updated from `022d160e13e378bdfe34e5222a0e89f3a51cf081` to `75648c23ca54bc860aa52d2c03848f601f51bae4`.

## Tests performed
- Verified that `drs.repos` is updated to the correct hash.
- Confirmed that `vcs import` completes successfully with the updated `drs.repos` file.
