### PR TITLE
feat: add configurable colcon parallel workers to Docker builds

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -112,7 +112,8 @@
     "UDISKS",
     "psmisc",
     "fuser",
-    "automounts"
+    "automounts",
+    "extraheader"
   ],
   "import": ["https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"],
   "useGitignore": true

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build Docker image using build.sh
         working-directory: ${{ matrix.build_dir }}
-        run: ./build.sh
+        run: ./build.sh --colcon-parallel-workers 2
 
       - name: Determine image tags
         id: tags

--- a/ansible/roles/drs_ros2_bridge_service/tasks/main.yaml
+++ b/ansible/roles/drs_ros2_bridge_service/tasks/main.yaml
@@ -6,7 +6,7 @@
 - name: Build DRS ROS 2 Bridge Docker image
   ansible.builtin.shell: |
     cd {{ playbook_dir }}/..
-    bash docker/ros2_bridge/build.sh
+    bash docker/ros2_bridge/build.sh --colcon-parallel-workers 2
   when: docker_build_script.stat.exists
   register: build_result
   changed_when: true

--- a/docker/calibration/Dockerfile
+++ b/docker/calibration/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+ARG COLCON_PARALLEL_WORKERS=2
+
 WORKDIR /opt/drs
 # COPY src/ /opt/drs/src/
 
@@ -58,9 +60,9 @@ RUN apt-get update && \
 # Create install directory
 RUN mkdir -p /opt/drs/install
 
-# Build DRS packages (parallel workers capped at 4)
+# Build DRS packages
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --symlink-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to sensor_calibration_tools
+    colcon build --symlink-install --install-base /opt/drs/install --parallel-workers ${COLCON_PARALLEL_WORKERS} --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to sensor_calibration_tools
 
 # Add cyclonedds.xml
 COPY docker/cyclonedds.xml /opt/drs/config/

--- a/docker/calibration/build.sh
+++ b/docker/calibration/build.sh
@@ -2,13 +2,37 @@
 
 set -e
 
+COLCON_PARALLEL_WORKERS=2
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --colcon-parallel-workers)
+        COLCON_PARALLEL_WORKERS="$2"
+        shift 2
+        ;;
+    *)
+        echo "Error: unknown option '$1'" >&2
+        echo "Usage: $0 [--colcon-parallel-workers <N>]" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if ! [[ $COLCON_PARALLEL_WORKERS =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: parallel workers must be a positive integer, got '$COLCON_PARALLEL_WORKERS'" >&2
+    exit 1
+fi
+
 # Change to repository root directory
 cd "$(dirname "$0")/../.."
 
 # Build the Docker image
-echo "Building DRS Docker image..."
+echo "Building DRS Docker image (parallel workers: ${COLCON_PARALLEL_WORKERS})..."
 
 # Build the image from repository root
-docker build -t tier4/pkg-drs-calibration:latest -f docker/calibration/Dockerfile .
+docker build \
+    --build-arg COLCON_PARALLEL_WORKERS="${COLCON_PARALLEL_WORKERS}" \
+    -t tier4/pkg-drs-calibration:latest \
+    -f docker/calibration/Dockerfile .
 
 echo "Docker image built successfully: tier4/pkg-drs-calibration:latest"

--- a/docker/ros2_bridge/Dockerfile
+++ b/docker/ros2_bridge/Dockerfile
@@ -53,6 +53,8 @@ RUN curl -sSL https://api.github.com/repos/ros-infrastructure/ros-apt-source/rel
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+ARG COLCON_PARALLEL_WORKERS=2
+
 WORKDIR /opt/drs
 COPY src/ /opt/drs/src/
 
@@ -68,9 +70,9 @@ RUN rosdep init && \
 # Create install directory
 RUN mkdir -p /opt/drs/install
 
-# Build DRS packages (parallel workers capped at 4)
+# Build DRS packages
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --symlink-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to ros2_bridge
+    colcon build --symlink-install --install-base /opt/drs/install --parallel-workers ${COLCON_PARALLEL_WORKERS} --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to ros2_bridge
 
 # Add cyclonedds.xml
 COPY docker/cyclonedds.xml /opt/drs/config/

--- a/docker/ros2_bridge/build.sh
+++ b/docker/ros2_bridge/build.sh
@@ -2,13 +2,37 @@
 
 set -e
 
+COLCON_PARALLEL_WORKERS=2
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --colcon-parallel-workers)
+        COLCON_PARALLEL_WORKERS="$2"
+        shift 2
+        ;;
+    *)
+        echo "Error: unknown option '$1'" >&2
+        echo "Usage: $0 [--colcon-parallel-workers <N>]" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if ! [[ $COLCON_PARALLEL_WORKERS =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: parallel workers must be a positive integer, got '$COLCON_PARALLEL_WORKERS'" >&2
+    exit 1
+fi
+
 # Change to repository root directory
 cd "$(dirname "$0")/../.."
 
 # Build the Docker image
-echo "Building DRS Docker image..."
+echo "Building DRS Docker image (parallel workers: ${COLCON_PARALLEL_WORKERS})..."
 
 # Build the image from repository root
-docker build -t tier4/drs-ros2-bridge:latest -f docker/ros2_bridge/Dockerfile .
+docker build \
+    --build-arg COLCON_PARALLEL_WORKERS="${COLCON_PARALLEL_WORKERS}" \
+    -t tier4/drs-ros2-bridge:latest \
+    -f docker/ros2_bridge/Dockerfile .
 
 echo "Docker image built successfully: tier4/drs-ros2-bridge:latest"

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -44,6 +44,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && \
     apt-get install -y --no-install-recommends ros-${ROS_DISTRO}-ros-core ros-dev-tools ros-${ROS_DISTRO}-rmw-cyclonedds-cpp ros-${ROS_DISTRO}-rosbag2-storage-mcap ros-${ROS_DISTRO}-rosbag2
 
+ARG COLCON_PARALLEL_WORKERS=2
+
 WORKDIR /opt/drs
 
 # Copy source code (assumes vcs import has been done in src directory)
@@ -63,9 +65,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Create install directory
 RUN mkdir -p /opt/drs/install
 
-# Build DRS packages (parallel workers capped at 4)
+# Build DRS packages
 RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --merge-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to drs_launch && \
+    colcon build --merge-install --install-base /opt/drs/install --parallel-workers ${COLCON_PARALLEL_WORKERS} --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to drs_launch && \
     # Remove unnecessary development files before copying to runtime
     find /opt/drs/install -name "*.a" -delete && \
     find /opt/drs/install -name "*.cmake" -delete && \

--- a/docker/runtime/build.sh
+++ b/docker/runtime/build.sh
@@ -2,13 +2,37 @@
 
 set -e
 
+COLCON_PARALLEL_WORKERS=2
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --colcon-parallel-workers)
+        COLCON_PARALLEL_WORKERS="$2"
+        shift 2
+        ;;
+    *)
+        echo "Error: unknown option '$1'" >&2
+        echo "Usage: $0 [--colcon-parallel-workers <N>]" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if ! [[ $COLCON_PARALLEL_WORKERS =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: parallel workers must be a positive integer, got '$COLCON_PARALLEL_WORKERS'" >&2
+    exit 1
+fi
+
 # Change to repository root directory
 cd "$(dirname "$0")/../.."
 
 # Build the Docker image
-echo "Building DRS Docker image..."
+echo "Building DRS Docker image (parallel workers: ${COLCON_PARALLEL_WORKERS})..."
 
 # Build the image from repository root
-docker build -t tier4/pkg-drs-runtime:latest -f docker/runtime/Dockerfile .
+docker build \
+    --build-arg COLCON_PARALLEL_WORKERS="${COLCON_PARALLEL_WORKERS}" \
+    -t tier4/pkg-drs-runtime:latest \
+    -f docker/runtime/Dockerfile .
 
 echo "Docker image built successfully: tier4/pkg-drs-runtime:latest"


### PR DESCRIPTION
## Summary
- Replace hardcoded `colcon build --parallel-workers 4` with a configurable parameter (default: 2) to prevent OOM during Docker image builds
- Add `ARG COLCON_PARALLEL_WORKERS=2` to all three Dockerfiles (runtime, calibration, ros2_bridge)
- Add `--colcon-parallel-workers <N>` CLI flag to each build.sh with input validation
- Explicitly set `--colcon-parallel-workers 2` in CI workflow and Ansible task

## How to verify

```bash
# Default (2 parallel workers)
./docker/runtime/build.sh

# Custom parallel workers
./docker/runtime/build.sh --colcon-parallel-workers 4

# Invalid input should fail with error
./docker/runtime/build.sh --colcon-parallel-workers abc
./docker/runtime/build.sh --colcon-parallel-workers 0
./docker/runtime/build.sh --unknown-flag
```

## Improvements
- Reduces default parallelism from 4 to 2, preventing excessive memory consumption during Docker builds
- Makes parallel worker count configurable per invocation without modifying Dockerfiles
- CI and Ansible callers explicitly declare their parallelism for clarity

## Limitations
- Reducing default from 4 to 2 increases build time on machines with sufficient resources; pass a higher value via `--colcon-parallel-workers` to restore previous behavior

## Test plan
- [ ] `docker/runtime/build.sh` builds successfully with no arguments (default: 2)
- [ ] `docker/runtime/build.sh --colcon-parallel-workers 4` builds with 4 parallel workers
- [ ] Invalid arguments (string, 0, negative) cause error exit with usage message
- [ ] CI workflow runs successfully
- [ ] Same behavior verified for calibration and ros2_bridge build.sh