### PR TITLE
docs: enforce English language rule for all text in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # AGENTS.md
 
-All text must be written in English.
+## Language
+
+- All text must be written in English — this includes source code comments, documentation, commit messages, PR titles, and PR descriptions.
 
 ## General rules
 


### PR DESCRIPTION
## Summary
- Move the English-only rule from an unstructured header line into a dedicated `## Language` section
- Expand scope to explicitly cover source code comments, documentation, commit messages, PR titles, and PR descriptions

## How to verify
- Open `AGENTS.md` and confirm the rule is under the new `## Language` section
- Confirm the `## General rules` section is unchanged

## Improvements
- Makes the English language requirement more discoverable with its own section heading
- Explicitly enumerates what "all text" covers, removing ambiguity

## Limitations
- None