### PR TITLE
fix(deps): update accelerated_image_processor commit pin

### DIFF
--- a/drs.repos
+++ b/drs.repos
@@ -10,7 +10,7 @@ repositories:
   dependencies/accelerated_image_processor:
     type: git
     url: https://github.com/tier4/accelerated_image_processor.git
-    version: 51467abb890e2c03594414dd28133f6b404acf2f  # fix/turbojpeg-cpucompressor-imageformat
+    version: 0c7a6639610579216ae35c8659c2929fc4b50d1a  # fix/turbojpeg-cpucompressor-imageformat
   dependencies/nebula:
     type: git
     url: https://github.com/tier4/nebula_drs.git


### PR DESCRIPTION
## Summary
- Update `dependencies/accelerated_image_processor` in `drs.repos` to `0c7a6639610579216ae35c8659c2929fc4b50d1a`
- Align dependency pin with upstream TurboJPEG ImageFormat-related fix revision
- Keep dependency tracking explicit and reproducible via commit pinning

## Test plan
- [x] `pre-commit run --all-files -c .pre-commit-config.yaml`
- [x] `pre-commit run --all-files -c .pre-commit-config-optional.yaml`
- [x] `pre-commit run --all-files -c .pre-commit-config-ansible.yaml`
- [ ] `vcs import src < drs.repos` in a clean workspace
- [ ] `colcon build --packages-up-to drs_launch --cmake-args -DCMAKE_BUILD_TYPE=Release`

Made with [Cursor](https://cursor.com)