### PR TITLE
docs(license): replace placeholder copyright metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright [2024] [TIER IV, Inc.]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Replace Apache 2.0 template placeholders in `LICENSE` with concrete project values
- Set copyright metadata to `Copyright [2024] [TIER IV, Inc.]`
- Remove ambiguity from boilerplate license text

## Test plan
- [x] `pre-commit run --all-files -c .pre-commit-config.yaml`
- [x] `pre-commit run --all-files -c .pre-commit-config-optional.yaml`
- [x] `pre-commit run --all-files -c .pre-commit-config-ansible.yaml`
- [x] Confirm `git diff -- LICENSE` shows only the copyright line update

Made with [Cursor](https://cursor.com)