### PR TITLE
fix(shell): enable SC2086 shellcheck rule and fix violations

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,2 +1,2 @@
 external-sources=true
-disable=SC2086,SC2164,SC1090,SC1091,SC2181
+disable=SC2164,SC1090,SC1091,SC2181

--- a/ansible/drs-setup.sh
+++ b/ansible/drs-setup.sh
@@ -74,8 +74,7 @@ fi
 # Install Ansible Galaxy requirements
 echo "Installing Ansible Galaxy requirements..."
 if [[ -f requirements.yml ]]; then
-    ansible-galaxy collection install -r requirements.yml --upgrade
-    if [[ $? -eq 0 ]]; then
+    if ansible-galaxy collection install -r requirements.yml --upgrade; then
         echo "Ansible Galaxy requirements installed successfully."
     else
         echo "WARNING: Failed to install some Ansible Galaxy requirements."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,9 +36,9 @@ else
     cd "$HOME"
 
     # Prepare runtime directory
-    mkdir -p /run/user/$USER_ID
-    chmod 700 /run/user/$USER_ID
-    chown "$USER_NAME":"$GROUP_NAME" /run/user/$USER_ID
+    mkdir -p /run/user/"$USER_ID"
+    chmod 700 /run/user/"$USER_ID"
+    chown "$USER_NAME":"$GROUP_NAME" /run/user/"$USER_ID"
 
     # Execute the command as the user
     exec gosu "$USER_NAME" "$@"


### PR DESCRIPTION
## Summary
- Enable SC2086 (double quote to prevent globbing and word splitting) in `.shellcheckrc`
- Fix all SC2086 violations: quote `$USER_ID` in `docker/entrypoint.sh`
- Fix SC2181 violation: use direct exit code check in `ansible/drs-setup.sh`

## Remaining disabled rules
| Rule | Reason |
|------|--------|
| SC2164 | `cd` failure handling — style preference |
| SC1090 | Dynamic `source` paths (e.g. `$ROS_DISTRO`) cannot be followed |
| SC1091 | Source targets exist only inside Docker containers |
| SC2181 | `$?` check pattern — style preference |

## Test plan
- [x] `pre-commit run shellcheck --all-files` passes locally
- [ ] Verify CI passes