### PR TITLE
ci(hadolint): enable SC2016 shellcheck rule in Dockerfile linting

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,3 +1,2 @@
 ignored:
   - DL3008
-  - SC2016


### PR DESCRIPTION
## Summary
- Remove SC2016 from hadolint ignore list to catch unintended single-quoted variable references in Dockerfiles
- DL3008 (pin apt package versions) remains ignored as version pinning is impractical for base image packages

## Test plan
- [x] `pre-commit run --all-files` passes locally
- [ ] Verify CI passes