### PR TITLE
style(yaml): enforce lint rules for parameter YAML files

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,8 +1,5 @@
 extends: default
 
-ignore: |
-  *.param.yaml
-
 rules:
   braces:
     level: error

--- a/src/individual_params/config/default/camera0/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera0/v4l2_camera.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    video_device: "/dev/video2"
-    output_encoding: "rgb8"
+    video_device: /dev/video2
+    output_encoding: rgb8
     image_size: [3840, 2160] # C2

--- a/src/individual_params/config/default/camera1/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera1/v4l2_camera.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    video_device: "/dev/video3"
-    output_encoding: "rgb8"
+    video_device: /dev/video3
+    output_encoding: rgb8
     image_size: [3840, 2160] # C2

--- a/src/individual_params/config/default/camera2/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera2/v4l2_camera.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    video_device: "/dev/video0"
-    output_encoding: "rgb8"
+    video_device: /dev/video0
+    output_encoding: rgb8
     image_size: [2880, 1860] # C2

--- a/src/individual_params/config/default/camera3/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera3/v4l2_camera.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    video_device: "/dev/video1"
-    output_encoding: "rgb8"
+    video_device: /dev/video1
+    output_encoding: rgb8
     image_size: [2880, 1860] # C2

--- a/src/individual_params/config/default/camera4/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera4/v4l2_camera.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    video_device: "/dev/video2"
-    output_encoding: "rgb8"
+    video_device: /dev/video2
+    output_encoding: rgb8
     image_size: [3840, 2160] # C2

--- a/src/individual_params/config/default/camera5/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera5/v4l2_camera.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    video_device: "/dev/video3"
-    output_encoding: "rgb8"
+    video_device: /dev/video3
+    output_encoding: rgb8
     image_size: [3840, 2160] # C2

--- a/src/individual_params/config/default/camera6/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera6/v4l2_camera.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    video_device: "/dev/video0"
-    output_encoding: "rgb8"
+    video_device: /dev/video0
+    output_encoding: rgb8
     image_size: [2880, 1860] # C2

--- a/src/individual_params/config/default/camera7/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera7/v4l2_camera.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    video_device: "/dev/video1"
-    output_encoding: "rgb8"
+    video_device: /dev/video1
+    output_encoding: rgb8
     image_size: [2880, 1860] # C2

--- a/src/individual_params/config/default/oxts_driver.param.yaml
+++ b/src/individual_params/config/default/oxts_driver.param.yaml
@@ -1,6 +1,6 @@
 oxts_driver:
   ros__parameters:
-    #===============================================================================
+    # ===============================================================================
     # INS configuration (set up to match the unit)
     ## Unit IP address
     unit_ip: 192.168.4.250
@@ -9,19 +9,19 @@ oxts_driver:
     ## Path of NCOM to replay (optional, must be absolute path)
     # ncom: /default/ncom/path.ncom
     ## Topic to publish NCOM messages to
-    ncom_topic: "ncom"
+    ncom_topic: ncom
 
-    #===============================================================================
+    # ===============================================================================
     ## Rate is in Hz. 0 Hz => Message will not be published
     ### Configure sample rate of NCom (do not exceed output rate of ncom)
     ncom_rate: 100
 
-    #===============================================================================
+    # ===============================================================================
     ## Timing - how to timestamp messages published by the ROS driver
 
     # 0 => Timestamped by the ROS node time (future default)
     # 1 => Timestamped from NCom
     timestamp_mode: 0
-    #===============================================================================
+    # ===============================================================================
     use_sim_time: false
     wait_for_init: false

--- a/src/individual_params/config/default/oxts_ins.param.yaml
+++ b/src/individual_params/config/default/oxts_ins.param.yaml
@@ -1,9 +1,9 @@
 oxts_ins:
   ros__parameters:
-    #===============================================================================
+    # ===============================================================================
     # Configure ROS messages to be published by the node.
     ## Frames
-    frame_id: "oxts_link"
+    frame_id: oxts_link
     ## Configure individual topics
     ## Rates must be factors of the ncom_rate, configured above.
     ## Rates are in Hz. 0 Hz => Message will not be published
@@ -11,42 +11,42 @@ oxts_ins:
     ### where topic prefix is defined in the oxts_driver yaml
     ### Configure NCom (do not exceed output rate of ncom)
     ncom_rate: 100
-    ncom_topic: "ncom"
+    ncom_topic: ncom
     ### Publish string message
     pub_string_rate: 0
-    string_topic: "debug_string_pos"
+    string_topic: debug_string_pos
     ### Publish NavSatFix message
     pub_nav_sat_fix_rate: 10
-    nav_sat_fix_topic: "nav_sat_fix"
+    nav_sat_fix_topic: nav_sat_fix
     ### Publish Velocity message
     pub_velocity_rate: 50
-    velocity_topic: "velocity"
+    velocity_topic: velocity
     ### Publish Odometry message
     pub_odometry_rate: 50
-    odometry_topic: "odometry"
+    odometry_topic: odometry
     ### Publish Path message
     pub_path_rate: 0
-    path_topic: "path"
+    path_topic: path
     ### Defaults to "map", can be set to "odom" when emulating navsat_transform_node
-    pub_odometry_frame_id: "map"
+    pub_odometry_frame_id: map
     ### Publish TimeReference message
     pub_time_reference_rate: 0
-    time_reference_topic: "time_reference"
+    time_reference_topic: time_reference
     ### Publish PoseWithCovarianceStamped message
     pub_ecef_pos_rate: 0
-    ecef_pos_topic: "ecef_pos"
+    ecef_pos_topic: ecef_pos
     ### Publish OxTS NavSatRef message
     pub_nav_sat_ref_rate: 10
-    nav_sat_ref_topic: "nav_sat_ref"
+    nav_sat_ref_topic: nav_sat_ref
     ### Publish OxTS Lever Arm message
     pub_lever_arm_rate: 5
-    lever_arm_topic: "lever_arm"
+    lever_arm_topic: lever_arm
     ### Publish OxTS IMU Bias message
     pub_imu_bias_rate: 5
-    imu_bias_topic: "imu_bias"
+    imu_bias_topic: imu_bias
     ### Publish Imu message
     pub_imu_flag: true
-    imu_topic: "imu"
+    imu_topic: imu
     ### Broadcast TF messages for rviz visualization
     pub_tf_flag: false
     ### Source of the local reference frame


### PR DESCRIPTION
## Summary
- Remove `*.param.yaml` from `.yamllint.yaml` ignore list so parameter YAML files are linted
- Fix yamllint violations in camera and OxTS parameter configs (`quoted-strings` and `comments`)
- Keep parameter semantics unchanged while normalizing formatting for consistent lint compliance

## Test plan
- [x] `pre-commit run --all-files -c .pre-commit-config.yaml`
- [x] `pre-commit run --all-files`
- [x] Confirm `yamllint` passes across all tracked YAML files

Made with [Cursor](https://cursor.com)