### PR TITLE
refactor(launch): remove unused sensing and module ID args

### DIFF
--- a/src/drs_launch/launch/drs.launch.xml
+++ b/src/drs_launch/launch/drs.launch.xml
@@ -2,8 +2,6 @@
   <!-- Entry point of DRS launcher -->
   <arg name="vehicle_id" default="default"/>
   <arg name="drs_ecu_id" default="$(env DRS_ECU_ID)"/>
-  <arg name="sensing_system_id" default="$(env SENSING_SYSTEM_ID)"/>
-  <arg name="module_id" default="$(env MODULE_ID)"/>
   <arg name="live_sensor" default="True"
        description="If true, sensor drivers will be executed (for actual recording operation)"/>
   <arg name="publish_pointcloud" default="False"
@@ -21,8 +19,6 @@
 
   <include file="$(find-pkg-share drs_launch)/launch/drs_ecu$(var drs_ecu_id).launch.xml">
     <arg name="vehicle_id" value="$(var vehicle_id)"/>
-    <arg name="sensing_system_id" value="$(var sensing_system_id)"/>
-    <arg name="module_id" value="$(var module_id)"/>
     <arg name="live_sensor" value="$(var live_sensor)"/>
     <arg name="publish_pointcloud" value="$(var publish_pointcloud)"/>
     <arg name="has_front4d" value="$(var has_front4d)"/>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -1,7 +1,5 @@
 <launch>
   <arg name="vehicle_id" default="default"/>
-  <arg name="sensing_system_id" default="unknown"/>
-  <arg name="module_id" default="unknown"/>
   <arg name="live_sensor" default="True"/>
   <arg name="publish_pointcloud" default="False"/>
   <arg name="has_front4d" default="False"/>

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -1,7 +1,5 @@
 <launch>
   <arg name="vehicle_id" default="default"/>
-  <arg name="sensing_system_id" default="unknown"/>
-  <arg name="module_id" default="unknown"/>
   <arg name="live_sensor" default="True"/>
   <arg name="publish_pointcloud" default="False"/>
   <arg name="has_vehicle_can" default="False"/>


### PR DESCRIPTION
## Summary
- Remove unused `sensing_system_id` and `module_id` arguments from `drs.launch.xml`, `drs_ecu0.launch.xml`, and `drs_ecu1.launch.xml`
- Remove forwarding of those arguments from `drs.launch.xml` to ECU launch files
- Keep active launch behavior unchanged (`drs_ecu_id`, `vehicle_id`, `param_root_dir`, sensor and TF flows)

## Test plan
- [x] `pre-commit run --all-files -c .pre-commit-config.yaml`
- [x] `pre-commit run --files src/drs_launch/launch/drs.launch.xml src/drs_launch/launch/drs_ecu0.launch.xml src/drs_launch/launch/drs_ecu1.launch.xml`
- [ ] Run `ros2 launch drs_launch drs.launch.xml drs_ecu_id:=0`
- [ ] Run `ros2 launch drs_launch drs.launch.xml drs_ecu_id:=1`

Made with [Cursor](https://cursor.com)