### PR TITLE
refactor(launch): unify vehicle_id-based parameter routing

### DIFF
--- a/src/drs_launch/launch/component/drs_aeva.launch.xml
+++ b/src/drs_launch/launch/component/drs_aeva.launch.xml
@@ -1,8 +1,9 @@
 <launch>
+  <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="live_sensor"/>
   <arg name="lidar_position" default="front4d"/>
   <arg name="lidar_model"  default="Aeries2"/>
-  <arg name="config_file" default="$(find-pkg-share individual_params)/config/default/aeva_lidar.param.yaml"/>
+  <arg name="config_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aeva_lidar.param.yaml"/>
 
   <group>
     <let name="lidar_name" value="lidar_$(var lidar_position)"/>

--- a/src/drs_launch/launch/component/ins.launch.xml
+++ b/src/drs_launch/launch/component/ins.launch.xml
@@ -1,13 +1,13 @@
 <launch>
   <arg name="launch_driver" default="true" />
-
+  <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <group>
     <push-ros-namespace namespace="ins"/>
     <group>
       <push-ros-namespace namespace="oxts"/>
       <include file="$(find-pkg-share oxts)/launch/run.py">
-        <arg name="driver_param_path" value="$(find-pkg-share individual_params)/config/default/oxts_driver.param.yaml"/>
-        <arg name="ins_param_path" value="$(find-pkg-share individual_params)/config/default/oxts_ins.param.yaml"/>
+        <arg name="driver_param_path" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/oxts_driver.param.yaml"/>
+        <arg name="ins_param_path" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/oxts_ins.param.yaml"/>
         <arg name="launch_driver" value="$(var launch_driver)"/>
       </include>
     </group>

--- a/src/drs_launch/launch/component/multi_transform_publisher.launch.py
+++ b/src/drs_launch/launch/component/multi_transform_publisher.launch.py
@@ -2,19 +2,16 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     # Declare arguments
-    config_file_arg = DeclareLaunchArgument(
-        'config_file',
-        default_value=os.path.join(
-            get_package_share_directory('individual_params'),
-            'config/default/multi_tf_static.yaml'
-        ),
-        description='Path to YAML configuration file containing all transforms'
+    vehicle_id_arg = DeclareLaunchArgument(
+        'vehicle_id',
+        default_value=os.environ.get('VEHICLE_ID', 'default'),
+        description='Vehicle ID used to select the individual_params config directory'
     )
 
     publish_camera_optical_link_arg = DeclareLaunchArgument(
@@ -41,7 +38,12 @@ def generate_launch_description():
         executable='multi_transform_publisher',
         name='multi_transform_publisher',
         parameters=[{
-            'config_file': LaunchConfiguration('config_file'),
+            'config_file': PathJoinSubstitution([
+                get_package_share_directory('individual_params'),
+                'config',
+                LaunchConfiguration('vehicle_id'),
+                'multi_tf_static.yaml',
+            ]),
             'publish_camera_optical_link': LaunchConfiguration('publish_camera_optical_link'),
             'periodic_publish': LaunchConfiguration('periodic_publish'),
             'publish_period': LaunchConfiguration('publish_period')
@@ -50,7 +52,7 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
-        config_file_arg,
+        vehicle_id_arg,
         publish_camera_optical_link_arg,
         periodic_publish_arg,
         publish_period_arg,

--- a/src/drs_launch/launch/drs.launch.xml
+++ b/src/drs_launch/launch/drs.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- Entry point of DRS launcher -->
-  <arg name="vehicle_id" default="default"/>
+  <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="drs_ecu_id" default="$(env DRS_ECU_ID)"/>
   <arg name="sensing_system_id" default="$(env SENSING_SYSTEM_ID)"/>
   <arg name="module_id" default="$(env MODULE_ID)"/>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="vehicle_id" default="default"/>
+  <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="sensing_system_id" default="unknown"/>
   <arg name="module_id" default="unknown"/>
   <arg name="live_sensor" default="True"/>
@@ -81,6 +81,7 @@
     <group>
       <include file="$(find-pkg-share drs_launch)/launch/component/ins.launch.xml">
         <arg name="launch_driver" value="$(var live_sensor)"/>
+        <arg name="vehicle_id" value="$(var vehicle_id)"/>
       </include>
     </group>
 
@@ -104,7 +105,7 @@
   <!-- TF static publisher for all transforms -->
   <group if="$(var publish_tf)">
     <include file="$(find-pkg-share drs_launch)/launch/component/multi_transform_publisher.launch.py">
-      <arg name="config_file" value="$(var param_root_dir)/multi_tf_static.yaml"/>
+      <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="publish_camera_optical_link" value="True"/>
     </include>
   </group>

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="vehicle_id" default="default"/>
+  <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="sensing_system_id" default="unknown"/>
   <arg name="module_id" default="unknown"/>
   <arg name="live_sensor" default="True"/>

--- a/src/drs_launch/launch/drs_offline.launch.xml
+++ b/src/drs_launch/launch/drs_offline.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="vehicle_id" default="default"/>
+  <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="live_sensor" default="False"
        description="If true, sensor drivers will be executed (for actual recording operation)"/>
   <arg name="publish_pointcloud" default="True"
@@ -130,7 +130,7 @@
   <!-- TF static publisher for all transforms -->
   <group if="$(var publish_tf)">
     <include file="$(find-pkg-share drs_launch)/launch/component/multi_transform_publisher.launch.py">
-      <arg name="config_file" value="$(var param_root_dir)/multi_tf_static.yaml"/>
+      <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="publish_camera_optical_link" value="True"/>
     </include>
   </group>


### PR DESCRIPTION
## Summary
- Route launch-time parameter file resolution through `vehicle_id` consistently across DRS launch entry points and component launch files
- Update INS and AEVA launch files to load parameters from `individual_params/config/<vehicle_id>/...`
- Replace `multi_transform_publisher` `config_file` override with an explicit `vehicle_id` argument and standard path resolution

## Test plan
- [x] `pre-commit run --all-files -c .pre-commit-config.yaml`
- [x] `pre-commit run --files src/drs_launch/launch/component/drs_aeva.launch.xml src/drs_launch/launch/component/ins.launch.xml src/drs_launch/launch/component/multi_transform_publisher.launch.py src/drs_launch/launch/drs.launch.xml src/drs_launch/launch/drs_ecu0.launch.xml src/drs_launch/launch/drs_ecu1.launch.xml src/drs_launch/launch/drs_offline.launch.xml`
- [ ] `ros2 launch drs_launch drs.launch.xml drs_ecu_id:=0 vehicle_id:=default`
- [ ] `ros2 launch drs_launch drs.launch.xml drs_ecu_id:=1 vehicle_id:=default`
- [ ] `ros2 launch drs_launch drs_offline.launch.xml vehicle_id:=default`

Made with [Cursor](https://cursor.com)