### PR TITLE
fix(launch): unify lidar_driver_type default to seyond

### DIFF
--- a/ansible/inventory/group_vars/all.yaml
+++ b/ansible/inventory/group_vars/all.yaml
@@ -13,7 +13,7 @@ drs_build_type: RelWithDebInfo
 has_raspi_controller: false
 has_vehicle_can: false
 has_dashboard_service: false
-lidar_driver_type: nebula
+lidar_driver_type: seyond
 
 # This option specifies the camera configuration used.
 # If using both C3 and C2 cameras: "-4 C3 -4 C2"

--- a/src/drs_launch/launch/drs.launch.xml
+++ b/src/drs_launch/launch/drs.launch.xml
@@ -12,7 +12,7 @@
        description="Should be False when LiDAR-camera extrinsic calibration"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"
        description="Root directory for sensor parameters"/>
-  <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE)"
+  <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"
        description="Type of LiDAR driver to use: nebula or seyond"/>
   <arg name="has_vehicle_can" default="$(env HAS_VEHICLE_CAN)"
        description="Should be True when vehicle CAN is available"/>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -5,6 +5,7 @@
   <arg name="has_front4d" default="False"/>
   <arg name="publish_tf" default="True"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
+  <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"/>
   <arg name="has_vehicle_can" default="False"/>
 
   <group>

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -5,6 +5,7 @@
   <arg name="has_vehicle_can" default="False"/>
   <arg name="publish_tf" default="True"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
+  <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"/>
 
   <group>
     <push-ros-namespace namespace="sensing"/>

--- a/src/drs_launch/launch/drs_offline.launch.xml
+++ b/src/drs_launch/launch/drs_offline.launch.xml
@@ -8,7 +8,7 @@
   <arg name="concatenate_pointcloud" default="False"
        description="If true, pointclouds from all LiDARs will be concatenated into a single topic"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
-  <arg name="lidar_driver_type" default="nebula" description="Type of LiDAR driver to use: nebula or seyond"/>
+  <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)" description="Type of LiDAR driver to use: nebula or seyond"/>
 
   <group if="$(eval &quot;'$(var lidar_driver_type)' == 'nebula'&quot;)">
     <push-ros-namespace namespace="sensing"/>


### PR DESCRIPTION
## Summary
- Unify `lidar_driver_type` default value to `seyond` (via `$(env LIDAR_DRIVER_TYPE seyond)`) across all launch files
- Add missing `lidar_driver_type` arg declaration to `drs_ecu0.launch.xml` and `drs_ecu1.launch.xml`
- Update Ansible default from `nebula` to `seyond` to match
- Add env fallback to `drs.launch.xml` (previously had no fallback, causing error when `LIDAR_DRIVER_TYPE` was unset)
- Replace hardcoded `nebula` default in `drs_offline.launch.xml` with env-based default

## How to verify
- Launch with `LIDAR_DRIVER_TYPE` unset: all files should default to `seyond`
- Launch with `LIDAR_DRIVER_TYPE=nebula`: all files should use `nebula`
- `grep -r lidar_driver_type src/drs_launch/launch/` confirms consistent defaults

## Improvements
- Eliminates inconsistent defaults that could cause different behavior depending on which launch file was used
- Prevents launch failure when `LIDAR_DRIVER_TYPE` env var is not set

## Limitations
- `has_vehicle_can` in `drs.launch.xml` still uses `$(env HAS_VEHICLE_CAN)` without a fallback — out of scope for this PR

## Test plan
- [ ] `ros2 launch drs_launch drs.launch.xml` with `LIDAR_DRIVER_TYPE` unset — defaults to seyond
- [ ] `ros2 launch drs_launch drs_ecu0.launch.xml` — defaults to seyond
- [ ] `ros2 launch drs_launch drs_ecu1.launch.xml` — defaults to seyond
- [ ] `ros2 launch drs_launch drs_offline.launch.xml` — defaults to seyond
- [ ] `LIDAR_DRIVER_TYPE=nebula ros2 launch drs_launch drs.launch.xml` — uses nebula