### PR TITLE
refactor(launch): standardize boolean values to lowercase true/false

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -117,7 +117,8 @@
     "fuser",
     "automounts",
     "extraheader",
-    "suppr"
+    "suppr",
+    "nocasematch"
   ],
   "import": ["https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"],
   "useGitignore": true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 ### ROS 2 Launch files
 
 - Always use XML format for launch files unless there is a sufficient reason to use Python (e.g., complex conditional logic or dynamic computation that cannot be expressed in XML).
+- Use lowercase `true`/`false` for boolean values in launch files (not `True`/`False`).
 
 ### Docker
 

--- a/src/drs_launch/launch/component/accelerated_image_processor.launch.xml
+++ b/src/drs_launch/launch/component/accelerated_image_processor.launch.xml
@@ -10,7 +10,7 @@
   <!-- container name that this ROS node to be loaded -->
   <arg name="container_name" default="" />
   <!-- flag to use ROS 2 intra process -->
-  <arg name="use_intra_process" default="True" />
+  <arg name="use_intra_process" default="true" />
 
   <let name="empty_container_is_specified" value="$(eval 'not &quot;$(var container_name)&quot;')" />
   <!-- If container name is not specified,

--- a/src/drs_launch/launch/component/drs_camera.launch.py
+++ b/src/drs_launch/launch/component/drs_camera.launch.py
@@ -98,7 +98,8 @@ def launch_setup(context, *args, **kwargs):
         ],
         condition=IfCondition(Command([
             'bash -c "',
-            f'if [ "{live_sensor}" = "True" ] && [ "{set_readout_delay}" = "True" ]; then ',
+            f'shopt -s nocasematch; '
+            f'if [[ "{live_sensor}" == "true" ]] && [[ "{set_readout_delay}" == "true" ]]; then ',
             'echo true; else echo false; fi"'
         ])),
         output='screen'
@@ -142,7 +143,7 @@ def generate_launch_description():
 
     set_readout_delay_arg = DeclareLaunchArgument(
         'set_readout_delay',
-        default_value='True',
+        default_value='true',
         description='Whether to set readout delay'
     )
 

--- a/src/drs_launch/launch/component/drs_nebula.launch.xml
+++ b/src/drs_launch/launch/component/drs_nebula.launch.xml
@@ -2,7 +2,7 @@
   <arg name="lidar_position"/>
   <arg name="lidar_model"/>
   <arg name="live_sensor"/>
-  <arg name="publish_pointcloud" default="True"/>
+  <arg name="publish_pointcloud" default="true"/>
   <arg name="return_mode" default="Dual"/>
   <arg name="scan_phase" default="0.0"/>
   <arg name="min_range" default="0.0"/>
@@ -13,9 +13,9 @@
   <arg name="ptp_profile" default="1588v2"/>
   <arg name="ptp_transport_type" default="UDP"/>
   <arg name="ptp_switch_type" default="TSN"/>
-  <arg name="setup_sensor" default="True"/>
-  <arg name="retry_hw" default="True"/>
-  <arg name="debug_logging" default="False"/>
+  <arg name="setup_sensor" default="true"/>
+  <arg name="retry_hw" default="true"/>
+  <arg name="debug_logging" default="false"/>
   <arg name="calibration_file_path" default=""/>
 
 

--- a/src/drs_launch/launch/component/v4l2_camera.launch.xml
+++ b/src/drs_launch/launch/component/v4l2_camera.launch.xml
@@ -10,9 +10,9 @@
   <!-- container name that this ROS node to be loaded -->
   <arg name="container_name" default="" />
   <!-- flag to use ROS 2 intra process -->
-  <arg name="use_intra_process" default="True" />
+  <arg name="use_intra_process" default="true" />
   <!-- flag to use sensor data QoS -->
-  <arg name="use_sensor_data_qos" default="True" />
+  <arg name="use_sensor_data_qos" default="true" />
   <!-- publish frame number per second. value <= 0 means no limitation on publish rate -->
   <arg name="publish_rate" default="-1.0" />
 

--- a/src/drs_launch/launch/drs.launch.xml
+++ b/src/drs_launch/launch/drs.launch.xml
@@ -2,13 +2,13 @@
   <!-- Entry point of DRS launcher -->
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="drs_ecu_id" default="$(env DRS_ECU_ID)"/>
-  <arg name="live_sensor" default="True"
+  <arg name="live_sensor" default="true"
        description="If true, sensor drivers will be executed (for actual recording operation)"/>
-  <arg name="publish_pointcloud" default="False"
+  <arg name="publish_pointcloud" default="false"
        description="If false, pointcloud decoding will not be performed (for actual recording operation)"/>
-  <arg name="has_front4d" default="False"
+  <arg name="has_front4d" default="false"
        description="Should be True when a front-mounted 4D LiDAR is present"/>
-  <arg name="publish_tf" default="True"
+  <arg name="publish_tf" default="true"
        description="Should be False when LiDAR-camera extrinsic calibration"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"
        description="Root directory for sensor parameters"/>

--- a/src/drs_launch/launch/drs.launch.xml
+++ b/src/drs_launch/launch/drs.launch.xml
@@ -7,15 +7,15 @@
   <arg name="publish_pointcloud" default="false"
        description="If false, pointcloud decoding will not be performed (for actual recording operation)"/>
   <arg name="has_front4d" default="false"
-       description="Should be True when a front-mounted 4D LiDAR is present"/>
+       description="Should be true when a front-mounted 4D LiDAR is present"/>
   <arg name="publish_tf" default="true"
-       description="Should be False when LiDAR-camera extrinsic calibration"/>
+       description="Should be false when LiDAR-camera extrinsic calibration"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"
        description="Root directory for sensor parameters"/>
   <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"
        description="Type of LiDAR driver to use: nebula or seyond"/>
   <arg name="has_vehicle_can" default="$(env HAS_VEHICLE_CAN)"
-       description="Should be True when vehicle CAN is available"/>
+       description="Should be true when vehicle CAN is available"/>
 
   <include file="$(find-pkg-share drs_launch)/launch/drs_ecu$(var drs_ecu_id).launch.xml">
     <arg name="vehicle_id" value="$(var vehicle_id)"/>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -1,12 +1,12 @@
 <launch>
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
-  <arg name="live_sensor" default="True"/>
-  <arg name="publish_pointcloud" default="False"/>
-  <arg name="has_front4d" default="False"/>
-  <arg name="publish_tf" default="True"/>
+  <arg name="live_sensor" default="true"/>
+  <arg name="publish_pointcloud" default="false"/>
+  <arg name="has_front4d" default="false"/>
+  <arg name="publish_tf" default="true"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
   <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"/>
-  <arg name="has_vehicle_can" default="False"/>
+  <arg name="has_vehicle_can" default="false"/>
 
   <group>
     <push-ros-namespace namespace="sensing"/>
@@ -17,7 +17,7 @@
         <arg name="camera_id" value="0"/>
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="False"/>
+        <arg name="set_readout_delay" value="false"/>
         <arg name="startup_delay" value="0.0"/>
       </include>
 
@@ -25,7 +25,7 @@
         <arg name="camera_id" value="1"/>
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="False"/>
+        <arg name="set_readout_delay" value="false"/>
         <arg name="startup_delay" value="0.1"/>
       </include>
 
@@ -33,7 +33,7 @@
         <arg name="camera_id" value="2"/>
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="True"/>
+        <arg name="set_readout_delay" value="true"/>
         <arg name="startup_delay" value="0.2"/>
       </include>
 
@@ -41,7 +41,7 @@
         <arg name="camera_id" value="3"/>
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="True"/>
+        <arg name="set_readout_delay" value="true"/>
         <arg name="startup_delay" value="0.3"/>
       </include>
     </group>
@@ -105,7 +105,7 @@
   <group if="$(var publish_tf)">
     <include file="$(find-pkg-share drs_launch)/launch/component/multi_transform_publisher.launch.xml">
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
-      <arg name="publish_camera_optical_link" value="True"/>
+      <arg name="publish_camera_optical_link" value="true"/>
     </include>
   </group>
 

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -1,9 +1,9 @@
 <launch>
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
-  <arg name="live_sensor" default="True"/>
-  <arg name="publish_pointcloud" default="False"/>
-  <arg name="has_vehicle_can" default="False"/>
-  <arg name="publish_tf" default="True"/>
+  <arg name="live_sensor" default="true"/>
+  <arg name="publish_pointcloud" default="false"/>
+  <arg name="has_vehicle_can" default="false"/>
+  <arg name="publish_tf" default="true"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
   <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"/>
 
@@ -16,7 +16,7 @@
         <arg name="camera_id" value="4"/>
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="False"/>
+        <arg name="set_readout_delay" value="false"/>
         <arg name="startup_delay" value="0.0"/>
       </include>
 
@@ -24,7 +24,7 @@
         <arg name="camera_id" value="5"/>
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="False"/>
+        <arg name="set_readout_delay" value="false"/>
         <arg name="startup_delay" value="0.1"/>
       </include>
 
@@ -32,7 +32,7 @@
         <arg name="camera_id" value="6"/>
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="True"/>
+        <arg name="set_readout_delay" value="true"/>
         <arg name="startup_delay" value="0.2"/>
       </include>
 
@@ -40,7 +40,7 @@
         <arg name="camera_id" value="7"/>
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="True"/>
+        <arg name="set_readout_delay" value="true"/>
         <arg name="startup_delay" value="0.3"/>
       </include>
     </group>

--- a/src/drs_launch/launch/drs_offline.launch.xml
+++ b/src/drs_launch/launch/drs_offline.launch.xml
@@ -1,11 +1,11 @@
 <launch>
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
-  <arg name="live_sensor" default="False"
+  <arg name="live_sensor" default="false"
        description="If true, sensor drivers will be executed (for actual recording operation)"/>
-  <arg name="publish_pointcloud" default="True"
+  <arg name="publish_pointcloud" default="true"
        description="If false, pointcloud decoding will not be performed (for actual recording operation)"/>
-  <arg name="publish_tf" default="False"/>
-  <arg name="concatenate_pointcloud" default="False"
+  <arg name="publish_tf" default="false"/>
+  <arg name="concatenate_pointcloud" default="false"
        description="If true, pointclouds from all LiDARs will be concatenated into a single topic"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
   <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)" description="Type of LiDAR driver to use: nebula or seyond"/>
@@ -131,7 +131,7 @@
   <group if="$(var publish_tf)">
     <include file="$(find-pkg-share drs_launch)/launch/component/multi_transform_publisher.launch.xml">
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
-      <arg name="publish_camera_optical_link" value="True"/>
+      <arg name="publish_camera_optical_link" value="true"/>
     </include>
   </group>
 


### PR DESCRIPTION
## Summary
- Standardize all boolean `default=""` and `value=""` attributes in XML launch files from `True`/`False` to `true`/`false`
- Update `drs_camera.launch.py` to accept both `True`/`False` and `true`/`false` via case-insensitive bash comparison (`shopt -s nocasematch`)
- Add lowercase boolean convention rule to `AGENTS.md`

## Changed files
- **7 XML launch files**: `drs.launch.xml`, `drs_ecu0.launch.xml`, `drs_ecu1.launch.xml`, `drs_offline.launch.xml`, `v4l2_camera.launch.xml`, `accelerated_image_processor.launch.xml`, `drs_nebula.launch.xml`
- **1 Python launch file**: `drs_camera.launch.py` — case-insensitive comparison + default value update
- **AGENTS.md** — added boolean convention rule

## How to verify
- `grep -rn 'default="True\|default="False\|value="True\|value="False"' src/drs_launch/launch/**/*.xml` returns no matches
- Launch any configuration and verify boolean parameters behave identically

## Improvements
- Consistent boolean style across all launch files, aligned with ROS 2 convention
- `drs_camera.launch.py` now tolerates both cases, preventing breakage if callers use either convention

## Limitations
- Python launch files (`drs_camera.launch.py`) still use Python-native `True`/`False` for Python boolean literals (e.g., `'use_sensor_data_qos': False`) — these are not XML attributes and are correct as-is

## Test plan
- [ ] `ros2 launch drs_launch drs.launch.xml` — verify all nodes start correctly
- [ ] `ros2 launch drs_launch drs_ecu0.launch.xml` — verify camera readout delay setter launches for camera 2 and 3
- [ ] `ros2 launch drs_launch drs_offline.launch.xml publish_tf:=true` — verify TF publisher starts
- [ ] Override with uppercase: `ros2 launch drs_launch drs_ecu0.launch.xml live_sensor:=True` — verify still works