### PR TITLE
chore(deps): update accelerated_image_processor to main

### DIFF
--- a/drs.repos
+++ b/drs.repos
@@ -10,7 +10,7 @@ repositories:
   dependencies/accelerated_image_processor:
     type: git
     url: https://github.com/tier4/accelerated_image_processor.git
-    version: 0c7a6639610579216ae35c8659c2929fc4b50d1a  # fix/turbojpeg-cpucompressor-imageformat
+    version: a93473691e88f24b7655025a1a5348bf9982933c  # main
   dependencies/nebula:
     type: git
     url: https://github.com/tier4/nebula_drs.git


### PR DESCRIPTION
## Summary
- Update `accelerated_image_processor` pinned version from `fix/turbojpeg-cpucompressor-imageformat` branch (`0c7a663`) to `main` branch HEAD (`a934736`)

## How to verify
- `vcs import dependencies < drs.repos` succeeds and clones the correct commit
- `colcon build --packages-select accelerated_image_processor` builds successfully

## Improvements
- Pins to `main` branch, incorporating the turbojpeg/cpucompressor/imageformat fix plus any subsequent changes

## Test plan
- [ ] `vcs import` with updated repos file succeeds
- [ ] Full build passes with the updated dependency