### PR TITLE
fix(launch): replace bash command injection with Python condition in drs_camera

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -117,8 +117,7 @@
     "fuser",
     "automounts",
     "extraheader",
-    "suppr",
-    "nocasematch"
+    "suppr"
   ],
   "import": ["https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"],
   "useGitignore": true

--- a/src/drs_launch/launch/component/drs_camera.launch.py
+++ b/src/drs_launch/launch/component/drs_camera.launch.py
@@ -3,7 +3,7 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction, TimerAction, OpaqueFunction
 from launch.conditions import IfCondition
-from launch.substitutions import Command, LaunchConfiguration
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes, Node, PushRosNamespace
 from launch_ros.descriptions import ComposableNode
 
@@ -96,12 +96,9 @@ def launch_setup(context, *args, **kwargs):
             f'{param_root_dir}/camera{camera_id}/readout_delay.param.yaml',
             {'target_v4l2_node': 'v4l2_camera'}
         ],
-        condition=IfCondition(Command([
-            'bash -c "',
-            f'shopt -s nocasematch; '
-            f'if [[ "{live_sensor}" == "true" ]] && [[ "{set_readout_delay}" == "true" ]]; then ',
-            'echo true; else echo false; fi"'
-        ])),
+        condition=IfCondition(
+            'true' if live_sensor.lower() == 'true' and set_readout_delay.lower() == 'true' else 'false'
+        ),
         output='screen'
     )
 


### PR DESCRIPTION
## Summary
- Replace `Command([bash -c ...])` with a pure Python boolean check in `drs_camera.launch.py`
- The previous implementation interpolated user-controllable launch arguments (`live_sensor`, `set_readout_delay`) directly into a bash f-string via `Command()`, creating a command injection vector
- The new approach uses `str.lower() == 'true'` in Python — safer, simpler, and correctly handles case-insensitive boolean values without relying on `shopt -s nocasematch`
- Removes `nocasematch` from `.cspell.json` as it is no longer referenced

## Test plan
- [ ] Verify `drs_camera.launch.py` launches correctly with `live_sensor:=true set_readout_delay:=true`
- [ ] Verify `readout_setter_node` is skipped when `set_readout_delay:=false`
- [ ] Verify mixed-case values (`True`, `TRUE`) are accepted