### PR TITLE
feat(launch): explicitly set use_v4l2_buffer_timestamps to true

### DIFF
--- a/src/drs_launch/launch/component/drs_camera.launch.py
+++ b/src/drs_launch/launch/component/drs_camera.launch.py
@@ -16,6 +16,7 @@ def launch_setup(context, *args, **kwargs):
     live_sensor = LaunchConfiguration('live_sensor').perform(context)
     set_readout_delay = LaunchConfiguration('set_readout_delay').perform(context)
     startup_delay = float(LaunchConfiguration('startup_delay').perform(context))
+    use_v4l2_buffer_timestamps = LaunchConfiguration('use_v4l2_buffer_timestamps').perform(context)
 
     # Create the root container name
     root_container_name = f'camera{camera_id}_container'
@@ -49,7 +50,8 @@ def launch_setup(context, *args, **kwargs):
                 'camera_info_url': f'file://{param_root_dir}/camera{camera_id}/camera_info.yaml',
                 'use_sensor_data_qos': False,
                 'publish_rate': -1.0,
-                'use_image_transport': False
+                'use_image_transport': False,
+                'use_v4l2_buffer_timestamps': use_v4l2_buffer_timestamps.lower() == 'true'
             }
         ],
         extra_arguments=[{'use_intra_process_comms': True}]
@@ -150,6 +152,12 @@ def generate_launch_description():
         description='Delay in seconds before starting the camera'
     )
 
+    use_v4l2_buffer_timestamps_arg = DeclareLaunchArgument(
+        'use_v4l2_buffer_timestamps',
+        default_value='true',
+        description='Use v4l2 buffer timestamps instead of ROS system time'
+    )
+
     # Return the launch description
     return LaunchDescription([
         camera_id_arg,
@@ -157,5 +165,6 @@ def generate_launch_description():
         live_sensor_arg,
         set_readout_delay_arg,
         startup_delay_arg,
+        use_v4l2_buffer_timestamps_arg,
         OpaqueFunction(function=launch_setup)
     ])

--- a/src/drs_launch/launch/component/v4l2_camera.launch.xml
+++ b/src/drs_launch/launch/component/v4l2_camera.launch.xml
@@ -11,6 +11,8 @@
   <arg name="container_name" default="" />
   <!-- flag to use ROS 2 intra process -->
   <arg name="use_intra_process" default="true" />
+  <!-- flag to use v4l2 buffer timestamps -->
+  <arg name="use_v4l2_buffer_timestamps" default="true" />
   <!-- flag to use sensor data QoS -->
   <arg name="use_sensor_data_qos" default="true" />
   <!-- publish frame number per second. value <= 0 means no limitation on publish rate -->
@@ -29,6 +31,7 @@
       <param name="camera_frame_id" value="$(var camera_frame_id)" />
       <param name="camera_info_url" value="$(var camera_info_url)" />
       <param name="use_sensor_data_qos" value="$(var use_sensor_data_qos)" />
+      <param name="use_v4l2_buffer_timestamps" value="$(var use_v4l2_buffer_timestamps)" />
       <param name="publish_rate" value="$(var publish_rate)" />
     </node>
   </group>
@@ -46,6 +49,7 @@
         <param name="camera_frame_id" value="$(var camera_frame_id)" />
         <param name="camera_info_url" value="$(var camera_info_url)" />
         <param name="use_sensor_data_qos" value="$(var use_sensor_data_qos)" />
+        <param name="use_v4l2_buffer_timestamps" value="$(var use_v4l2_buffer_timestamps)" />
         <param name="publish_rate" value="$(var publish_rate)" />
         <param name="use_image_transport" value="false" />
         <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)" />


### PR DESCRIPTION
## Summary
- Add `use_v4l2_buffer_timestamps` parameter to both `drs_camera.launch.py` and `v4l2_camera.launch.xml`
- Default value is `true` (uses V4L2 kernel buffer timestamps for accurate multi-sensor synchronization)
- In `drs_camera.launch.py`, exposed as a `DeclareLaunchArgument` so callers can override it
- In `v4l2_camera.launch.xml`, added as `<arg>` and passed to both standalone node and composable node paths

## Why
Previously this relied on the upstream `ros2_v4l2_camera` node's internal default. Making it explicit improves visibility and allows override without source edits.

## Test plan
- [ ] `ros2 launch drs_launch drs_camera.launch.py --show-args` shows `use_v4l2_buffer_timestamps` with default `true`
- [ ] `ros2 launch drs_launch v4l2_camera.launch.xml --show-args` shows `use_v4l2_buffer_timestamps` with default `true`
- [ ] Verify camera timestamps use V4L2 buffer timestamps in actual recording