### PR TITLE
chore(params): remove C2 comments from v4l2_camera param files

### DIFF
--- a/src/individual_params/config/default/camera0/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera0/v4l2_camera.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     video_device: /dev/video2
     output_encoding: rgb8
-    image_size: [3840, 2160] # C2
+    image_size: [3840, 2160]

--- a/src/individual_params/config/default/camera1/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera1/v4l2_camera.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     video_device: /dev/video3
     output_encoding: rgb8
-    image_size: [3840, 2160] # C2
+    image_size: [3840, 2160]

--- a/src/individual_params/config/default/camera2/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera2/v4l2_camera.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     video_device: /dev/video0
     output_encoding: rgb8
-    image_size: [2880, 1860] # C2
+    image_size: [2880, 1860]

--- a/src/individual_params/config/default/camera3/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera3/v4l2_camera.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     video_device: /dev/video1
     output_encoding: rgb8
-    image_size: [2880, 1860] # C2
+    image_size: [2880, 1860]

--- a/src/individual_params/config/default/camera4/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera4/v4l2_camera.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     video_device: /dev/video2
     output_encoding: rgb8
-    image_size: [3840, 2160] # C2
+    image_size: [3840, 2160]

--- a/src/individual_params/config/default/camera5/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera5/v4l2_camera.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     video_device: /dev/video3
     output_encoding: rgb8
-    image_size: [3840, 2160] # C2
+    image_size: [3840, 2160]

--- a/src/individual_params/config/default/camera6/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera6/v4l2_camera.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     video_device: /dev/video0
     output_encoding: rgb8
-    image_size: [2880, 1860] # C2
+    image_size: [2880, 1860]

--- a/src/individual_params/config/default/camera7/v4l2_camera.param.yaml
+++ b/src/individual_params/config/default/camera7/v4l2_camera.param.yaml
@@ -2,4 +2,4 @@
   ros__parameters:
     video_device: /dev/video1
     output_encoding: rgb8
-    image_size: [2880, 1860] # C2
+    image_size: [2880, 1860]


### PR DESCRIPTION
## Summary
- Remove `# C2` inline comments from all default v4l2_camera param files (camera0–7)