### PR TITLE
fix(launch): replace $(eval) with if/unless to avoid Python eval errors

### DIFF
--- a/src/drs_launch/launch/component/drs_nebula.launch.xml
+++ b/src/drs_launch/launch/component/drs_nebula.launch.xml
@@ -21,8 +21,8 @@
 
   <group>
     <let name="lidar_name" value="lidar_$(var lidar_position)"/>
-    <let name="debug_level" value="debug" if="$(eval $(var debug_logging))"/>
-    <let name="debug_level" value="info" unless="$(eval $(var debug_logging))"/>
+    <let name="debug_level" value="debug" if="$(var debug_logging)"/>
+    <let name="debug_level" value="info" unless="$(var debug_logging)"/>
 
     <node pkg="nebula_ros" exec="seyond_ros_wrapper_node"
       name="$(var lidar_name)" output="screen">

--- a/src/drs_launch/launch/component/drs_seyond.launch.xml
+++ b/src/drs_launch/launch/component/drs_seyond.launch.xml
@@ -14,7 +14,9 @@
 
   <group>
     <node pkg="seyond" exec="seyond_component_node" name="$(var lidar_name)" output="screen" >
-      <param name="replay_rosbag" value="$(eval 'not $(var live_sensor)')" />
+      <let name="replay_rosbag" value="true" unless="$(var live_sensor)"/>
+      <let name="replay_rosbag" value="false" if="$(var live_sensor)"/>
+      <param name="replay_rosbag" value="$(var replay_rosbag)" />
       <param name="packet_mode" value="true" />
       <param name="publish_pointcloud" value="$(var publish_pointcloud)" />
       <param name="frame_id" value="$(var lidar_name)" />

--- a/src/drs_launch/launch/component/drs_seyond.launch.xml
+++ b/src/drs_launch/launch/component/drs_seyond.launch.xml
@@ -13,9 +13,9 @@
   <arg name="min_range" default="0.4" />
 
   <group>
+    <let name="replay_rosbag" value="true" unless="$(var live_sensor)"/>
+    <let name="replay_rosbag" value="false" if="$(var live_sensor)"/>
     <node pkg="seyond" exec="seyond_component_node" name="$(var lidar_name)" output="screen" >
-      <let name="replay_rosbag" value="true" unless="$(var live_sensor)"/>
-      <let name="replay_rosbag" value="false" if="$(var live_sensor)"/>
       <param name="replay_rosbag" value="$(var replay_rosbag)" />
       <param name="packet_mode" value="true" />
       <param name="publish_pointcloud" value="$(var publish_pointcloud)" />


### PR DESCRIPTION
## Summary
- Replace `$(eval $(var debug_logging))` with native `if`/`unless` attributes in `drs_nebula.launch.xml`
- Replace `$(eval 'not $(var live_sensor)')` with `<let>` + `if`/`unless` in `drs_seyond.launch.xml`
- Fixes launch failure: `name 'true' is not defined` caused by Python `eval()` receiving lowercase `true`/`false` strings

## Background
`$(eval ...)` in ROS 2 launch XML evaluates expressions as Python code. Python requires `True`/`False` (capitalized), but ROS 2 launch convention uses lowercase `true`/`false`. The `if`/`unless` attributes handle lowercase strings natively, so removing `$(eval)` avoids the mismatch entirely.

## Test plan
- [ ] Launch `drs.launch.xml` with default parameters and confirm no `name 'true' is not defined` error
- [ ] Verify `debug_logging=true` sets debug level to `debug` in nebula driver
- [ ] Verify `live_sensor=false` sets `replay_rosbag` to `true` in seyond driver