### PR TITLE
fix(repos): use HTTPS URL for c2_readout_delay_setter

### DIFF
--- a/drs.repos
+++ b/drs.repos
@@ -34,7 +34,7 @@ repositories:
     version: 75648c23ca54bc860aa52d2c03848f601f51bae4  # feat/data_recording_system
   dependencies/c2_readout_delay_setter:
     type: git
-    url: git@github.com:tier4/c2_readout_delay_setter.git
+    url: https://github.com/tier4/c2_readout_delay_setter.git
     version: 47ed673503a4796099478e1e11646a11d2709c7d  # feat/drs
   proto_recorder:
     type: git


### PR DESCRIPTION
## Summary
- Replace SSH URL (`git@github.com:`) with HTTPS URL for `c2_readout_delay_setter` in `drs.repos`
- Enables cloning with `gh auth` token-based authentication without SSH key setup

## Note
CI and Ansible scripts that convert SSH→HTTPS via `sed` will simply no-op on this entry. No other changes are needed.

## Test plan
- [ ] `vcs import --force src < drs.repos` succeeds with HTTPS-based authentication