### PR TITLE
feat(scripts): add setup_repos.sh wrapper for vcs import with token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ For detailed dependency libraries, please refer to [`docker/runtime/Dockerfile`]
 
 ## Build
 
+This project depends on the private repository [tier4/c2_readout_delay_setter](https://github.com/tier4/c2_readout_delay_setter) (will be made public soon). `<GITHUB_TOKEN>` is a GitHub personal access token with permission to clone this repository. You can create one at <https://github.com/settings/tokens>.
+
 ```bash
 git clone https://github.com/tier4/data_recording_system.git
 cd data_recording_system
-vcs import --force src < drs.repos
+./scripts/setup_repos.sh --token <GITHUB_TOKEN>
 rosdep install -y -r --from-paths `colcon list --packages-up-to drs_launch -p` --ignore-src
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to drs_launch
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ For detailed dependency libraries, please refer to [`docker/runtime/Dockerfile`]
 
 ## Build
 
-This project depends on the private repository [tier4/c2_readout_delay_setter](https://github.com/tier4/c2_readout_delay_setter) (will be made public soon). `<GITHUB_TOKEN>` is a GitHub personal access token with permission to clone this repository. You can create one at <https://github.com/settings/tokens>.
+<!-- markdown-link-check-disable -->
+
+This project depends on the private repository [tier4/c2_readout_delay_setter](https://github.com/tier4/c2_readout_delay_setter) (will be made public soon).
+
+<!-- markdown-link-check-enable --> `<GITHUB_TOKEN>` is a GitHub personal access token with permission to clone this repository. You can create one at <https://github.com/settings/tokens>.
 
 ```bash
 git clone https://github.com/tier4/data_recording_system.git

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ For detailed dependency libraries, please refer to [`docker/runtime/Dockerfile`]
 
 This project depends on the private repository [tier4/c2_readout_delay_setter](https://github.com/tier4/c2_readout_delay_setter) (will be made public soon).
 
-<!-- markdown-link-check-enable --> `<GITHUB_TOKEN>` is a GitHub personal access token with permission to clone this repository. You can create one at <https://github.com/settings/tokens>.
+<!-- markdown-link-check-enable -->
+
+`<GITHUB_TOKEN>` is a GitHub personal access token with permission to clone this repository. You can create one at <https://github.com/settings/tokens>.
 
 ```bash
 git clone https://github.com/tier4/data_recording_system.git

--- a/scripts/setup_repos.sh
+++ b/scripts/setup_repos.sh
@@ -29,4 +29,4 @@ fi
 GIT_CONFIG_COUNT=1 \
     GIT_CONFIG_KEY_0="url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf" \
     GIT_CONFIG_VALUE_0="https://github.com/" \
-    vcs import --recursive --force "${REPO_ROOT}" <"${REPOS_FILE}"
+    vcs import --recursive --force "${REPO_ROOT}/src" <"${REPOS_FILE}"

--- a/scripts/setup_repos.sh
+++ b/scripts/setup_repos.sh
@@ -6,6 +6,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPOS_FILE="${REPO_ROOT}/drs.repos"
 
 GITHUB_TOKEN=""
+RECURSIVE=false
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -13,8 +14,12 @@ while [ $# -gt 0 ]; do
         GITHUB_TOKEN="${2:?--token requires a value}"
         shift 2
         ;;
+    --recursive | -r)
+        RECURSIVE=true
+        shift
+        ;;
     *)
-        echo "Usage: $0 --token|-t <GITHUB_TOKEN>" >&2
+        echo "Usage: $0 --token|-t <GITHUB_TOKEN> [--recursive|-r]" >&2
         exit 1
         ;;
     esac
@@ -26,7 +31,12 @@ if [ -z "${GITHUB_TOKEN}" ]; then
     exit 1
 fi
 
+VCS_ARGS=(--force)
+if [ "${RECURSIVE}" = true ]; then
+    VCS_ARGS+=(--recursive)
+fi
+
 GIT_CONFIG_COUNT=1 \
     GIT_CONFIG_KEY_0="url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf" \
     GIT_CONFIG_VALUE_0="https://github.com/" \
-    vcs import --recursive --force "${REPO_ROOT}/src" <"${REPOS_FILE}"
+    vcs import "${VCS_ARGS[@]}" "${REPO_ROOT}/src" <"${REPOS_FILE}"

--- a/scripts/setup_repos.sh
+++ b/scripts/setup_repos.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPOS_FILE="${REPO_ROOT}/drs.repos"
+
+GITHUB_TOKEN=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --token | -t)
+        GITHUB_TOKEN="${2:?--token requires a value}"
+        shift 2
+        ;;
+    *)
+        echo "Usage: $0 --token|-t <GITHUB_TOKEN>" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ -z "${GITHUB_TOKEN}" ]; then
+    echo "Error: --token|-t <GITHUB_TOKEN> is required." >&2
+    echo "Usage: $0 --token|-t <GITHUB_TOKEN>" >&2
+    exit 1
+fi
+
+GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_KEY_0="url.https://x-access-token:${GITHUB_TOKEN}@github.com/.insteadOf" \
+    GIT_CONFIG_VALUE_0="https://github.com/" \
+    vcs import --recursive --force "${REPO_ROOT}" <"${REPOS_FILE}"


### PR DESCRIPTION
## Summary
- Add `scripts/setup_repos.sh` that wraps `vcs import` with git URL rewriting to inject a GitHub token for cloning private repositories
- Update README.md Build section to use the new script and document the token requirement

## Test plan
- [ ] Run `./scripts/setup_repos.sh --token <valid_token>` and verify all repos are cloned
- [ ] Run `./scripts/setup_repos.sh` without `--token` and verify it exits with an error message
- [ ] Run `./scripts/setup_repos.sh -t <valid_token>` and verify short flag works