### PR TITLE
feat(scripts): add dependency checks to build.sh and setup_repos.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,13 @@
 #!/bin/bash
+set -euo pipefail
+
+if ! command -v colcon &>/dev/null; then
+    echo "Error: colcon is not installed." >&2
+    echo "" >&2
+    echo "Install it with:" >&2
+    echo "  sudo apt install python3-colcon-common-extensions" >&2
+    echo "  # or: pip install colcon-common-extensions" >&2
+    exit 1
+fi
 
 colcon build --merge-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo --packages-up-to drs_launch

--- a/scripts/setup_repos.sh
+++ b/scripts/setup_repos.sh
@@ -5,6 +5,28 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPOS_FILE="${REPO_ROOT}/drs.repos"
 
+missing_deps=()
+
+if ! command -v git &>/dev/null; then
+    missing_deps+=("git")
+fi
+
+if ! command -v vcs &>/dev/null; then
+    missing_deps+=("vcs (vcstool)")
+fi
+
+if [ ${#missing_deps[@]} -gt 0 ]; then
+    echo "Error: The following required commands are not installed:" >&2
+    for dep in "${missing_deps[@]}"; do
+        echo "  - ${dep}" >&2
+    done
+    echo "" >&2
+    echo "Install them with:" >&2
+    echo "  sudo apt install git python3-vcstool" >&2
+    echo "  # or: pip install vcstool" >&2
+    exit 1
+fi
+
 GITHUB_TOKEN=""
 RECURSIVE=false
 


### PR DESCRIPTION
## Summary
- Add dependency checks to `setup_repos.sh` for `git` and `vcs` commands
- Add dependency check to `build.sh` for `colcon` command
- Add `set -euo pipefail` to `build.sh` for consistent error handling

When required commands are missing, scripts now display clear error messages with installation instructions before exiting.

## Test plan
- [ ] Run `build.sh` without `colcon` installed and verify error message
- [ ] Run `setup_repos.sh` without `vcs` installed and verify error message
- [ ] Run both scripts with all dependencies installed and verify normal execution