### PR TITLE
chore(repos): pin proto_recorder to v0.1.0 tag

### DIFF
--- a/drs.repos
+++ b/drs.repos
@@ -39,7 +39,7 @@ repositories:
   proto_recorder:
     type: git
     url: https://github.com/tier4/proto_recorder.git
-    version: 13b9c84aacf16e9d7a22915c3b929e4ddf68e6a6  # main
+    version: v0.1.0
   drs-api:
     type: git
     url: https://github.com/tier4/drs-api.git


### PR DESCRIPTION
## Summary
- Replace proto_recorder commit hash (`13b9c84`) with the `v0.1.0` release tag in `drs.repos`
- Improves readability and makes version tracking explicit

## Test plan
- [ ] Verify `vcs import` resolves `v0.1.0` tag correctly
- [ ] Confirm CI build succeeds with the tagged version