### PR TITLE
fix(launch): increase camera startup_delay with 2.5s intervals

### DIFF
--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -26,7 +26,7 @@
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
         <arg name="set_readout_delay" value="false"/>
-        <arg name="startup_delay" value="0.1"/>
+        <arg name="startup_delay" value="2.5"/>
       </include>
 
       <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
@@ -34,7 +34,7 @@
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
         <arg name="set_readout_delay" value="true"/>
-        <arg name="startup_delay" value="0.2"/>
+        <arg name="startup_delay" value="5.0"/>
       </include>
 
       <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
@@ -42,7 +42,7 @@
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
         <arg name="set_readout_delay" value="true"/>
-        <arg name="startup_delay" value="0.3"/>
+        <arg name="startup_delay" value="7.5"/>
       </include>
     </group>
 

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -25,7 +25,7 @@
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
         <arg name="set_readout_delay" value="false"/>
-        <arg name="startup_delay" value="0.1"/>
+        <arg name="startup_delay" value="2.5"/>
       </include>
 
       <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
@@ -33,7 +33,7 @@
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
         <arg name="set_readout_delay" value="true"/>
-        <arg name="startup_delay" value="0.2"/>
+        <arg name="startup_delay" value="5.0"/>
       </include>
 
       <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
@@ -41,7 +41,7 @@
         <arg name="param_root_dir" value="$(var param_root_dir)"/>
         <arg name="live_sensor" value="$(var live_sensor)"/>
         <arg name="set_readout_delay" value="true"/>
-        <arg name="startup_delay" value="0.3"/>
+        <arg name="startup_delay" value="7.5"/>
       </include>
     </group>
 


### PR DESCRIPTION
## Summary
- Increase `startup_delay` for camera groups from 0.1/0.2/0.3s to 2.5/5.0/7.5s
- Applied to both ECU0 (`drs_ecu0.launch.xml`) and ECU1 (`drs_ecu1.launch.xml`)
- Wider 2.5s intervals between camera group initializations to avoid race conditions

## Test plan
- [ ] Verify all camera groups start correctly on ECU0
- [ ] Verify all camera groups start correctly on ECU1
- [ ] Confirm no initialization race conditions during launch