### PR TITLE
fix(launch): align min_range/max_range with sensor detection specs

### DIFF
--- a/src/drs_launch/launch/component/drs_nebula.launch.xml
+++ b/src/drs_launch/launch/component/drs_nebula.launch.xml
@@ -5,7 +5,7 @@
   <arg name="publish_pointcloud" default="true"/>
   <arg name="return_mode" default="Dual"/>
   <arg name="scan_phase" default="0.0"/>
-  <arg name="min_range" default="0.0"/>
+  <arg name="min_range" default="0.4"/>
   <arg name="max_range" default="300.0"/>
   <arg name="sensor_ip"/>
   <arg name="host_ip"/>

--- a/src/drs_launch/launch/component/drs_nebula_decoder.launch.xml
+++ b/src/drs_launch/launch/component/drs_nebula_decoder.launch.xml
@@ -3,8 +3,8 @@
   <arg name="lidar_model"/>
   <arg name="return_mode" default="Dual"/>
   <arg name="scan_phase" default="0.0"/>
-  <arg name="min_range" default="0.3"/>
-  <arg name="max_range" default="200.0"/>
+  <arg name="min_range" default="0.4"/>
+  <arg name="max_range" default="300.0"/>
   <arg name="frequency_ms" default="100.0"/>
   <arg name="use_sensor_time" default="true"/>
 

--- a/src/drs_launch/launch/component/drs_seyond.launch.xml
+++ b/src/drs_launch/launch/component/drs_seyond.launch.xml
@@ -9,7 +9,7 @@
   <arg name="multiple_return" default="1" />
   <arg name="continue_live" default="false" />
   <arg name="calibration_file_path" default="" />
-  <arg name="max_range" default="2000.0" />
+  <arg name="max_range" default="300.0" />
   <arg name="min_range" default="0.4" />
 
   <group>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -59,6 +59,8 @@
           <arg name="sensor_ip" value="192.168.2.201"/>
           <arg name="host_ip" value="192.168.2.1"/>
           <arg name="data_port" value="2368"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="300.0"/>
         </include>
       </group>
 
@@ -73,6 +75,8 @@
           <arg name="sensor_ip" value="192.168.2.203"/>
           <arg name="host_ip" value="192.168.2.1"/>
           <arg name="data_port" value="8010"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="70.0"/>
         </include>
       </group>
     </group>

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -58,6 +58,8 @@
           <arg name="sensor_ip" value="192.168.2.202"/>
           <arg name="host_ip" value="192.168.2.2"/>
           <arg name="data_port" value="2369"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="300.0"/>
         </include>
       </group>
 
@@ -72,6 +74,8 @@
           <arg name="sensor_ip" value="192.168.2.204"/>
           <arg name="host_ip" value="192.168.2.2"/>
           <arg name="data_port" value="8010"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="70.0"/>
         </include>
       </group>
     </group>

--- a/src/drs_launch/launch/drs_offline.launch.xml
+++ b/src/drs_launch/launch/drs_offline.launch.xml
@@ -19,8 +19,8 @@
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_nebula_decoder.launch.xml" if="$(var publish_pointcloud)">
           <arg name="lidar_position" value="front"/>
           <arg name="lidar_model" value="Falcon"/>
-          <arg name="min_range" value="0.3"/>
-          <arg name="max_range" value="200.0"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="300.0"/>
         </include>
       </group>
 
@@ -29,8 +29,8 @@
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_nebula_decoder.launch.xml" if="$(var publish_pointcloud)">
           <arg name="lidar_position" value="right"/>
           <arg name="lidar_model" value="RobinW"/>
-          <arg name="min_range" value="0.3"/>
-          <arg name="max_range" value="200.0"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="70.0"/>
         </include>
       </group>
 
@@ -39,8 +39,8 @@
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_nebula_decoder.launch.xml" if="$(var publish_pointcloud)">
           <arg name="lidar_position" value="rear"/>
           <arg name="lidar_model" value="Falcon"/>
-          <arg name="min_range" value="0.3"/>
-          <arg name="max_range" value="200.0"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="300.0"/>
         </include>
       </group>
 
@@ -49,8 +49,8 @@
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_nebula_decoder.launch.xml" if="$(var publish_pointcloud)">
           <arg name="lidar_position" value="left"/>
           <arg name="lidar_model" value="RobinW"/>
-          <arg name="min_range" value="0.3"/>
-          <arg name="max_range" value="200.0"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="70.0"/>
         </include>
       </group>
     </group>
@@ -71,6 +71,8 @@
           <arg name="sensor_ip" value="192.168.2.201"/>
           <arg name="host_ip" value="192.168.2.1"/>
           <arg name="data_port" value="2368"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="300.0"/>
         </include>
       </group>
 
@@ -85,6 +87,8 @@
           <arg name="sensor_ip" value="192.168.2.203"/>
           <arg name="host_ip" value="192.168.2.1"/>
           <arg name="data_port" value="8010"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="70.0"/>
         </include>
       </group>
 
@@ -99,6 +103,8 @@
           <arg name="sensor_ip" value="192.168.2.202"/>
           <arg name="host_ip" value="192.168.2.2"/>
           <arg name="data_port" value="2369"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="300.0"/>
         </include>
       </group>
 
@@ -113,6 +119,8 @@
           <arg name="sensor_ip" value="192.168.2.204"/>
           <arg name="host_ip" value="192.168.2.2"/>
           <arg name="data_port" value="8010"/>
+          <arg name="min_range" value="0.4"/>
+          <arg name="max_range" value="70.0"/>
         </include>
       </group>
     </group>


### PR DESCRIPTION
## Summary
- Falcon (front/rear): `min_range=0.4m`, `max_range=300m`
- RobinW (right/left): `min_range=0.4m`, `max_range=70m`
- Values based on detection range at 10% reflectivity
- Consistent across all launch files: nebula, seyond, ecu0, ecu1, offline

## Changed Files
- `drs_nebula.launch.xml` — update component default values
- `drs_nebula_decoder.launch.xml` — update component default values
- `drs_seyond.launch.xml` — fix max_range from 2000 to 300
- `drs_ecu0.launch.xml` — explicitly specify min_range/max_range
- `drs_ecu1.launch.xml` — explicitly specify min_range/max_range
- `drs_offline.launch.xml` — update and add min_range/max_range

## Test plan
- [ ] Verify pointcloud output with nebula driver in offline playback
- [ ] Verify pointcloud output with seyond driver in offline playback
- [ ] Verify pointcloud output on ecu0/ecu1 with live sensor connection