### PR TITLE
fix(launch): disable publish_pointcloud by default for nebula and seyond

### DIFF
--- a/src/drs_launch/launch/component/drs_nebula.launch.xml
+++ b/src/drs_launch/launch/component/drs_nebula.launch.xml
@@ -2,7 +2,7 @@
   <arg name="lidar_position"/>
   <arg name="lidar_model"/>
   <arg name="live_sensor"/>
-  <arg name="publish_pointcloud" default="true"/>
+  <arg name="publish_pointcloud" default="false"/>
   <arg name="return_mode" default="Dual"/>
   <arg name="scan_phase" default="0.0"/>
   <arg name="min_range" default="0.0"/>

--- a/src/drs_launch/launch/component/drs_seyond.launch.xml
+++ b/src/drs_launch/launch/component/drs_seyond.launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <arg name="lidar_position"/>
   <arg name="live_sensor" default="true" />
-  <arg name="publish_pointcloud" default="true" />
+  <arg name="publish_pointcloud" default="false" />
   <arg name="lidar_name" default="lidar_$(var lidar_position)" />
   <arg name="sensor_ip" default="172.168.1.10" />
   <arg name="data_port" default="8010" />


### PR DESCRIPTION
## Summary
- Change `publish_pointcloud` default from `true` to `false` in `drs_nebula.launch.xml` and `drs_seyond.launch.xml`
- Prevents unnecessary pointcloud publishing during recording by default

## Test plan
- [ ] Verify nebula driver launches without pointcloud publishing by default
- [ ] Verify seyond driver launches without pointcloud publishing by default
- [ ] Verify pointcloud publishing still works when explicitly set to `true`