### PR TITLE
fix(recorder): align camera6/camera7 camera_info rate limits on ecu1

### DIFF
--- a/ansible/roles/drs_recorder_service/templates/record_topics_ecu1.yaml.j2
+++ b/ansible/roles/drs_recorder_service/templates/record_topics_ecu1.yaml.j2
@@ -22,10 +22,10 @@ topics:
     max_rate: 21.0
   - name: /sensing/camera/camera6/camera_info
     min_rate: 18.0
-    max_rate: 50.0
+    max_rate: 21.0
   - name: /sensing/camera/camera7/camera_info
-    min_rate: 1.0
-    max_rate: 50.0
+    min_rate: 18.0
+    max_rate: 21.0
   # For lidar topics,
   # min_rate is set to 90% of the expected rate
   # max_rate is set to 150% of the expected rate


### PR DESCRIPTION
## Summary
- Fix inconsistent rate limits for camera6 and camera7 `camera_info` topics in ecu1 recording config
- camera6: `max_rate` 50.0 → 21.0
- camera7: `min_rate` 1.0 → 18.0, `max_rate` 50.0 → 21.0
- Now consistent with camera0–camera5 (all 18.0–21.0)

## Test plan
- [ ] Verify ecu1 recording starts without rate limit violations for camera6/camera7
- [ ] Verify no false-positive warnings from topic rate monitoring