### PR TITLE
fix(service): start drs-sensor after ptp4l

### DIFF
--- a/ansible/roles/drs_sensor_service/templates/drs-sensor.service.jinja2
+++ b/ansible/roles/drs_sensor_service/templates/drs-sensor.service.jinja2
@@ -1,7 +1,7 @@
 [Unit]
 Description=DRS Launch Service
 Requires=network-online.target systemd-modules-load.service
-After=network-online.target cyclonedds-local.service systemd-modules-load.service
+After=network-online.target cyclonedds-local.service systemd-modules-load.service ptp4l.service
 
 [Service]
 Type=exec


### PR DESCRIPTION
## Summary
- Add `ptp4l.service` to the `After=` directive in `drs-sensor.service` so the sensor driver waits for PTP daemon startup before launching
- Prevents Seyond LiDAR driver from flooding logs with PTP clock sync errors (`failed to step clock: Invalid argument`) when ptp4l has not yet started

## Note
- Uses `After=` (ordering only), not `Requires=` — so environments without ptp4l enabled are unaffected

## Test plan
- [ ] Deploy to a sensing ECU and verify `systemctl show drs-sensor.service -p After` includes `ptp4l.service`
- [ ] Reboot and confirm drs-sensor starts after ptp4l in `journalctl` timestamps
- [ ] Verify Seyond LiDAR logs no longer show PTP errors at startup