### PR TITLE
fix(config): enable wait_for_init in OxTS driver params

### DIFF
--- a/src/individual_params/config/default/oxts_driver.param.yaml
+++ b/src/individual_params/config/default/oxts_driver.param.yaml
@@ -24,4 +24,4 @@ oxts_driver:
     timestamp_mode: 0
     # ===============================================================================
     use_sim_time: false
-    wait_for_init: false
+    wait_for_init: true


### PR DESCRIPTION
## Summary
- Set `wait_for_init` from `false` to `true` in OxTS driver default params

## Test plan
- [ ] Verify OxTS driver waits for initialization before publishing data