### PR TITLE
fix(docs): add --rosdistro humble flag to rosdep install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ This project depends on the private repository [tier4/c2_readout_delay_setter](h
 git clone https://github.com/tier4/data_recording_system.git
 cd data_recording_system
 ./scripts/setup_repos.sh --token <GITHUB_TOKEN>
-rosdep install -y -r --from-paths `colcon list --packages-up-to drs_launch proto_recorder ros2_bridge -p` --ignore-src
+rosdep install -y -r --from-paths `colcon list --packages-up-to drs_launch proto_recorder ros2_bridge -p` --ignore-src --rosdistro humble
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to drs_launch proto_recorder ros2_bridge
 ```


### PR DESCRIPTION
## Summary
- Add `--rosdistro humble` flag to the `rosdep install` command in README.md to explicitly specify the ROS distribution, preventing resolution errors on environments where the default distro is not set or differs.

## Test plan
- [ ] Verify `rosdep install` command works correctly with the `--rosdistro humble` flag