### PR TITLE
fix: sync to x replace fuser with mtime check

### DIFF
--- a/ansible/inventory/group_vars/all.yaml
+++ b/ansible/inventory/group_vars/all.yaml
@@ -37,7 +37,7 @@ sync_to_x_source_dir: /mnt/ssd/data
 sync_to_x_destinations:
   - /mnt/external/data
   - /mnt/nas/data
-sync_to_x_rsync_bw_limit: 100m
+sync_to_x_rsync_bw_limit: 200m
 sync_to_x_timer_interval: 1min
 
 # Journald Configuration

--- a/ansible/roles/sync_to_x/defaults/main.yaml
+++ b/ansible/roles/sync_to_x/defaults/main.yaml
@@ -9,6 +9,7 @@ sync_to_x_hostname: "{{ ansible_hostname }}"
 sync_to_x_rsync_bw_limit: 100m
 sync_to_x_timer_interval: 1min
 sync_to_x_free_space_limit_gb: 10
+sync_to_x_active_file_threshold_sec: 30
 
 # System paths
 sync_to_x_script_path: /opt/drs/service/sync_to_x/sync_to_x.sh

--- a/ansible/roles/sync_to_x/templates/sync_to_x.sh.j2
+++ b/ansible/roles/sync_to_x/templates/sync_to_x.sh.j2
@@ -97,7 +97,11 @@ error_exit() {
         # Skip files modified within the threshold (i.e., recording is still active or
         # just finished). Avoids fuser/lsof which cause excessive NFS stat() calls when
         # SOURCE_DIR or DEST is on a NAS mount, leading to severe slowdowns.
-        file_mtime=$(stat -c %Y "$mcap_file" 2>/dev/null || echo 0)
+        # On stat failure, skip rather than proceeding — the file will be retried next tick.
+        if ! file_mtime=$(stat -c %Y "$mcap_file" 2>/dev/null); then
+            echo "Skipping (stat failed): $mcap_file"
+            continue
+        fi
         now=$(date +%s)
         if [ $((now - file_mtime)) -lt {{ sync_to_x_active_file_threshold_sec }} ]; then
             echo "Skipping recently modified file (active within {{ sync_to_x_active_file_threshold_sec }}s): $mcap_file"

--- a/ansible/roles/sync_to_x/templates/sync_to_x.sh.j2
+++ b/ansible/roles/sync_to_x/templates/sync_to_x.sh.j2
@@ -94,10 +94,14 @@ error_exit() {
     # Find mcap files (excluding metadata.yaml) and sort by modification time (oldest first)
     find "$SOURCE_DIR" -name "*.mcap" -type f -printf '%T@ %p\n' | sort -n | cut -d' ' -f2- | while read -r mcap_file; do
 
-        # Check if file is currently open by any process (e.g., recording is still active)
-        if fuser "$mcap_file" > /dev/null 2>&1; then
-             echo "Skipping active file (in use): $mcap_file"
-             continue
+        # Check if file was recently modified (i.e., recording is still active).
+        # Avoids fuser/lsof which cause excessive NFS stat() calls when SOURCE_DIR
+        # or DEST is on a NAS mount, leading to severe slowdowns.
+        file_mtime=$(stat -c %Y "$mcap_file" 2>/dev/null || echo 0)
+        now=$(date +%s)
+        if [ $((now - file_mtime)) -lt 10 ]; then
+            echo "Skipping recently modified file (active within 10s): $mcap_file"
+            continue
         fi
 
         # Get relative path (to preserve directory structure)

--- a/ansible/roles/sync_to_x/templates/sync_to_x.sh.j2
+++ b/ansible/roles/sync_to_x/templates/sync_to_x.sh.j2
@@ -94,13 +94,13 @@ error_exit() {
     # Find mcap files (excluding metadata.yaml) and sort by modification time (oldest first)
     find "$SOURCE_DIR" -name "*.mcap" -type f -printf '%T@ %p\n' | sort -n | cut -d' ' -f2- | while read -r mcap_file; do
 
-        # Check if file was recently modified (i.e., recording is still active).
-        # Avoids fuser/lsof which cause excessive NFS stat() calls when SOURCE_DIR
-        # or DEST is on a NAS mount, leading to severe slowdowns.
+        # Skip files modified within the threshold (i.e., recording is still active or
+        # just finished). Avoids fuser/lsof which cause excessive NFS stat() calls when
+        # SOURCE_DIR or DEST is on a NAS mount, leading to severe slowdowns.
         file_mtime=$(stat -c %Y "$mcap_file" 2>/dev/null || echo 0)
         now=$(date +%s)
-        if [ $((now - file_mtime)) -lt 10 ]; then
-            echo "Skipping recently modified file (active within 10s): $mcap_file"
+        if [ $((now - file_mtime)) -lt {{ sync_to_x_active_file_threshold_sec }} ]; then
+            echo "Skipping recently modified file (active within {{ sync_to_x_active_file_threshold_sec }}s): $mcap_file"
             continue
         fi
 


### PR DESCRIPTION
## Description

This PR replaces the `fuser` command with an `mtime` (modification time) check in the `sync-to-x` data synchronization process. 

Previously, using `fuser` caused significant slowdowns when operating over network file systems (NFS). Using an `mtime`-based check provides a much more efficient way to determine if a file is still actively being written to.

Additionally, this PR includes the following updates:
- **Configurable Active-File Threshold**: The threshold for determining an active file based on `mtime` is now configurable via an Ansible parameter.
- **Transfer Bandwidth Limitation Fix**: Adjusted the `rsync` bandwidth limit (increased from 100m to 200m) to resolve transfer bottlenecks.

## How to verify

1. Deploy the updated `sync-to-x` configuration.
2. Initiate a data recording session that triggers the synchronization process.
3. Observe the system resource usage and ensure there are no slowdowns or hangs associated with NFS file checks.
4. Check the transfer speeds with both a NAS and an external SSD to confirm the bandwidth limit fix is working as expected (up to 200m).

## Improvements

- Eliminates NFS-related slowdowns by removing the `fuser` dependency.
- Improves the flexibility of the synchronization service by making the `mtime` threshold configurable.
- Resolves previous transfer bandwidth limitations, allowing for faster data synchronization to external devices (NAS and SSD).

## Limitations

- None identified.
