### PR TITLE
chore(repos): bump drs-api to 89e49cba

### DIFF
--- a/drs.repos
+++ b/drs.repos
@@ -43,7 +43,7 @@ repositories:
   drs-api:
     type: git
     url: https://github.com/tier4/drs-api.git
-    version: a1f6884a2db8545d36ca2885444affe3c510b384  # develop
+    version: 89e49cbab4ba19f3c698057e1b35da04cccf8f27  # develop
   bag_converter:
     type: git
     url: https://github.com/tier4/bag_converter.git


### PR DESCRIPTION
## Summary

- Bump `drs-api` in `drs.repos` from `a1f6884` to `89e49cba` (develop)

## Test plan

- [x] Verified Transfer-related changes are reflected on HILS

🤖 Generated with [Claude Code](https://claude.com/claude-code)