### PR TITLE
feat(build): enable --symlink-install in colcon build

### DIFF
--- a/ansible/roles/drs/tasks/main.yaml
+++ b/ansible/roles/drs/tasks/main.yaml
@@ -60,7 +60,7 @@
     cd {{ drs_src_dir }}
     source /opt/drs/config/drs.env
     source /opt/ros/humble/setup.bash
-    colcon build --merge-install --install-base {{ drs_install_dir }} --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE={{ drs_build_type }} -DBUILD_TESTING=OFF --packages-up-to {{ drs_packages | join(' ') }}
+    colcon build --merge-install --symlink-install --install-base {{ drs_install_dir }} --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE={{ drs_build_type }} -DBUILD_TESTING=OFF --packages-up-to {{ drs_packages | join(' ') }}
   args:
     executable: /bin/bash
   changed_when: true

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,4 +10,4 @@ if ! command -v colcon &>/dev/null; then
     exit 1
 fi
 
-colcon build --merge-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF --packages-up-to drs_launch proto_recorder ros2_bridge
+colcon build --merge-install --symlink-install --install-base /opt/drs/install --parallel-workers 4 --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF --packages-up-to drs_launch proto_recorder ros2_bridge


### PR DESCRIPTION
## Summary

- Add `--symlink-install` to `colcon build` in `ansible/roles/drs/tasks/main.yaml` and `scripts/build.sh`
- Launch files and Python interpreter scripts in the install prefix become symlinks into the source tree, so edits are reflected by restarting the node only — no rebuild required
- Compiled artifacts (`.so`) still require a full rebuild as usual

## Migration (one-time per Jetson device)

Before running the updated Ansible playbook, stop DRS services and wipe the install prefix to avoid mixed copy/symlink state:

```bash
sudo systemctl stop drs-sensor.service drs-ros2-bridge.service
sudo rm -rf /opt/drs/install
```

Also confirm the `colcon-symlink-install` plugin is available (included in `python3-colcon-common-extensions`):

```bash
python3 -m colcon info symlink-install
```

## Test plan

- [x] Run Ansible playbook on a Jetson device after migration steps above
- [x] Verify launch files are symlinks: `ls -la /opt/drs/install/share/drs_launch/launch/`
- [x] Edit a `.launch.xml`, restart the node, confirm change is reflected without rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)