### PR TITLE
chore: update repository name references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ This project depends on the private repository [tier4/c2_readout_delay_setter](h
 `<GITHUB_TOKEN>` is a GitHub personal access token with permission to clone this repository. You can create one at <https://github.com/settings/tokens>.
 
 ```bash
-git clone https://github.com/tier4/data_recording_system.git
-cd data_recording_system
+git clone https://github.com/tier4/drs.git
+cd drs
 ./scripts/setup_repos.sh --token <GITHUB_TOKEN>
 rosdep install -y -r --from-paths `colcon list --packages-up-to drs_launch proto_recorder ros2_bridge -p` --ignore-src
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to drs_launch proto_recorder ros2_bridge

--- a/drs.repos
+++ b/drs.repos
@@ -31,7 +31,7 @@ repositories:
   dependencies/oxts_ros2_driver:
     type: git
     url: https://github.com/tier4/oxts_ros2_driver.git
-    version: 75648c23ca54bc860aa52d2c03848f601f51bae4  # feat/data_recording_system
+    version: 75648c23ca54bc860aa52d2c03848f601f51bae4  # feat/drs
   dependencies/c2_readout_delay_setter:
     type: git
     url: https://github.com/tier4/c2_readout_delay_setter.git

--- a/drs.repos
+++ b/drs.repos
@@ -31,7 +31,7 @@ repositories:
   dependencies/oxts_ros2_driver:
     type: git
     url: https://github.com/tier4/oxts_ros2_driver.git
-    version: 75648c23ca54bc860aa52d2c03848f601f51bae4  # feat/drs
+    version: 75648c23ca54bc860aa52d2c03848f601f51bae4  # feat/data_recording_system
   dependencies/c2_readout_delay_setter:
     type: git
     url: https://github.com/tier4/c2_readout_delay_setter.git


### PR DESCRIPTION
## Summary
- Replace the README setup instructions that still referenced `data_recording_system` with `drs` after the repository rename.

## Detailed Description
The repository has been renamed from `data_recording_system` to `drs`, but the README clone command and checkout directory still used the old repository name. This PR updates those setup instructions so new checkouts use the current GitHub repository name.

The remaining `data_recording_system` text in `drs.repos` is intentionally preserved because it is a dependency branch name, not this repository name.

## How to Verify
- `rg data_recording_system README.md`
- `pre-commit run --all-files`

## Improvements
- Prevents users from cloning the old repository name from the README.
- Keeps dependency branch metadata unchanged where the old text is still semantically correct.

## Limitations
- This PR only updates textual README setup instructions; it does not rename any local checkout paths.