### PR TITLE
feat(config): add OxTS static transforms

### DIFF
--- a/src/individual_params/config/default/multi_tf_static.yaml
+++ b/src/individual_params/config/default/multi_tf_static.yaml
@@ -11,7 +11,7 @@ base_link:
     pitch: 0.0
     yaw: 0.0
 
-# LiDAR transforms
+# LiDAR & INS transforms
 drs_base_link:
   lidar_left:
     x: 0.026968
@@ -38,6 +38,23 @@ drs_base_link:
     x: 1.022
     y: 0.0
     z: 0.033
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0
+  oxts_link:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    roll: 3.141592653589793
+    pitch: 0.0
+    yaw: 0.0
+
+# Intra-INS transforms
+oxts_link:
+  imu_link:
+    x: 0.0
+    y: 0.0
+    z: 0.0
     roll: 0.0
     pitch: 0.0
     yaw: 0.0


### PR DESCRIPTION
## Summary
- Add `drs_base_link` to `oxts_link` and `oxts_link` to `imu_link` static transforms to the default multi TF static configuration.
- Update the section label from LiDAR-only to LiDAR and INS to match the added OxTS frames.

## Detailed Description
This change extends the default `multi_tf_static.yaml` so the consolidated static transform publisher includes the OxTS INS frame relationship. The new entries keep the existing single-parent YAML structure under `drs_base_link` and add the intra-INS `imu_link` child under `oxts_link`.

## How to Verify
- `pre-commit run --all-files`
- Launch `multi_transform_publisher` with the default `multi_tf_static.yaml` and confirm `oxts_link` and `imu_link` appear on `/tf_static`.

## Improvements
- Keeps INS transforms in the same default static TF configuration used by the rest of the sensor tree.
- Avoids duplicate top-level YAML keys for `drs_base_link`.

## Limitations
- The added transform values are limited to the default configuration and use the configured zero translations with the specified rotations.

Made with [Cursor](https://cursor.com)