### PR TITLE
feat(iptables): add INS routing rules for NTRIP Client internet access (ECU0 only)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -118,7 +118,9 @@
     "automounts",
     "extraheader",
     "suppr",
-    "TOCTOU"
+    "TOCTOU",
+    "conntrack",
+    "ctstate"
   ],
   "import": ["https://raw.githubusercontent.com/tier4/autoware-spell-check-dict/main/.cspell.json"],
   "useGitignore": true

--- a/ansible/roles/iptables/templates/add_iptables_rules.sh.j2
+++ b/ansible/roles/iptables/templates/add_iptables_rules.sh.j2
@@ -4,7 +4,7 @@
 iptables -t nat -A POSTROUTING -s 192.168.20.0/24 -d 192.168.10.0/24 -j MASQUERADE
 iptables -A FORWARD -i enP1p1s0 -o mgbe1 -j ACCEPT
 iptables -A FORWARD -i mgbe1 -o enP1p1s0 -j ACCEPT
-{% if drs_ecu_id == 0 %}
+{% if (drs_ecu_id | int) == 0 %}
 iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o enP1p1s0 -j MASQUERADE
 iptables -A FORWARD -i enP1p1s0 -o mgbe0 -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -A FORWARD -i mgbe0 -o enP1p1s0 -j ACCEPT

--- a/ansible/roles/iptables/templates/add_iptables_rules.sh.j2
+++ b/ansible/roles/iptables/templates/add_iptables_rules.sh.j2
@@ -4,3 +4,6 @@
 iptables -t nat -A POSTROUTING -s 192.168.20.0/24 -d 192.168.10.0/24 -j MASQUERADE
 iptables -A FORWARD -i enP1p1s0 -o mgbe1 -j ACCEPT
 iptables -A FORWARD -i mgbe1 -o enP1p1s0 -j ACCEPT
+iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o enP1p1s0 -j MASQUERADE
+iptables -A FORWARD -i enP1p1s0 -o mgbe0 -m state --state RELATED,ESTABLISHED -j ACCEPT
+iptables -A FORWARD -i mgbe0 -o enP1p1s0 -j ACCEPT

--- a/ansible/roles/iptables/templates/add_iptables_rules.sh.j2
+++ b/ansible/roles/iptables/templates/add_iptables_rules.sh.j2
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 # Add iptables rules for ECU network routing
-iptables -t nat -A POSTROUTING -s 192.168.20.0/24 -d 192.168.10.0/24 -j MASQUERADE
-iptables -A FORWARD -i enP1p1s0 -o mgbe1 -j ACCEPT
-iptables -A FORWARD -i mgbe1 -o enP1p1s0 -j ACCEPT
+iptables -t nat -C POSTROUTING -s 192.168.20.0/24 -d 192.168.10.0/24 -j MASQUERADE 2>/dev/null || \
+  iptables -t nat -A POSTROUTING -s 192.168.20.0/24 -d 192.168.10.0/24 -j MASQUERADE
+iptables -C FORWARD -i enP1p1s0 -o mgbe1 -j ACCEPT 2>/dev/null || \
+  iptables -A FORWARD -i enP1p1s0 -o mgbe1 -j ACCEPT
+iptables -C FORWARD -i mgbe1 -o enP1p1s0 -j ACCEPT 2>/dev/null || \
+  iptables -A FORWARD -i mgbe1 -o enP1p1s0 -j ACCEPT
 {% if (drs_ecu_id | int) == 0 %}
-iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o enP1p1s0 -j MASQUERADE
-iptables -A FORWARD -i enP1p1s0 -o mgbe0 -m state --state RELATED,ESTABLISHED -j ACCEPT
-iptables -A FORWARD -i mgbe0 -o enP1p1s0 -j ACCEPT
+iptables -t nat -C POSTROUTING -s 192.168.4.0/24 -o enP1p1s0 -j MASQUERADE 2>/dev/null || \
+  iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o enP1p1s0 -j MASQUERADE
+iptables -C FORWARD -i enP1p1s0 -o mgbe0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null || \
+  iptables -A FORWARD -i enP1p1s0 -o mgbe0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+iptables -C FORWARD -i mgbe0 -o enP1p1s0 -j ACCEPT 2>/dev/null || \
+  iptables -A FORWARD -i mgbe0 -o enP1p1s0 -j ACCEPT
 {% endif %}

--- a/ansible/roles/iptables/templates/add_iptables_rules.sh.j2
+++ b/ansible/roles/iptables/templates/add_iptables_rules.sh.j2
@@ -4,6 +4,8 @@
 iptables -t nat -A POSTROUTING -s 192.168.20.0/24 -d 192.168.10.0/24 -j MASQUERADE
 iptables -A FORWARD -i enP1p1s0 -o mgbe1 -j ACCEPT
 iptables -A FORWARD -i mgbe1 -o enP1p1s0 -j ACCEPT
+{% if drs_ecu_id == 0 %}
 iptables -t nat -A POSTROUTING -s 192.168.4.0/24 -o enP1p1s0 -j MASQUERADE
 iptables -A FORWARD -i enP1p1s0 -o mgbe0 -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -A FORWARD -i mgbe0 -o enP1p1s0 -j ACCEPT
+{% endif %}


### PR DESCRIPTION
## Summary

**INS routing — NTRIP Client internet access via ECU0**

The INS device (OxTS, connected to ECU0 via `mgbe0`, subnet `192.168.4.0/24`) runs an NTRIP Client that fetches DGPS correction data from the internet. This PR adds the required iptables NAT and forwarding rules to enable that outbound access through `enP1p1s0`.

- **Added:** NAT masquerade for `192.168.4.0/24` outbound via `enP1p1s0`
- **Added:** Stateful return-traffic forwarding (`enP1p1s0 → mgbe0`, `RELATED,ESTABLISHED`)
- **Added:** Forward from `mgbe0 → enP1p1s0` (INS-initiated outbound)
- **Fixed:** Rules wrapped in `{% if drs_ecu_id == 0 %}` — ECU1 has no INS on `mgbe0`

## Test plan
- [x] Deploy to ECU0: verify NTRIP Client can fetch DGPS corrections
- [x] Deploy to ECU1: verify no mgbe0 iptables rules are present
- [x] Restart iptables service: verify no duplicate rules appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)