### PR TITLE
feat(ci): add multi-arch (amd64 + arm64) build for pkg-drs-ros2-bridge

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -86,7 +86,7 @@ jobs:
           done
 
   build-and-push-ros2-bridge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -9,6 +9,7 @@ on:
       - develop/r36.4.0
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -28,14 +28,24 @@ jobs:
             local_image: tier4/pkg-drs-runtime:latest
             ghcr_image: ghcr.io/tier4/pkg-drs-runtime
             needs_vcs_import: true
+            runner: ubuntu-22.04
           - build_dir: docker/calibration
             local_image: tier4/pkg-drs-calibration:latest
             ghcr_image: ghcr.io/tier4/pkg-drs-calibration
             needs_vcs_import: false
+            runner: ubuntu-22.04
           - build_dir: docker/ros2_bridge
             local_image: tier4/drs-ros2-bridge:latest
             ghcr_image: ghcr.io/tier4/pkg-drs-ros2-bridge
             needs_vcs_import: true
+            platform_tag: amd64
+            runner: ubuntu-22.04
+          - build_dir: docker/ros2_bridge
+            local_image: tier4/drs-ros2-bridge:latest
+            ghcr_image: ghcr.io/tier4/pkg-drs-ros2-bridge
+            needs_vcs_import: true
+            platform_tag: arm64
+            runner: ubuntu-22.04-arm64
 
     steps:
       - name: Check out repository
@@ -66,15 +76,24 @@ jobs:
         id: tags
         run: |
           GHCR_IMAGE="${{ matrix.ghcr_image }}"
+          PLATFORM_TAG="${{ matrix.platform_tag }}"
           TAGS=""
 
           if [[ "${{ github.event_name }}" == "release" ]]; then
             # For GitHub releases (e.g., v1.0.0)
             TAG_NAME="${{ github.event.release.tag_name }}"
-            TAGS="${GHCR_IMAGE}:${TAG_NAME}"
+            if [[ -n "${PLATFORM_TAG}" ]]; then
+              TAGS="${GHCR_IMAGE}:${TAG_NAME}-${PLATFORM_TAG}"
+            else
+              TAGS="${GHCR_IMAGE}:${TAG_NAME}"
+            fi
           else
             # For pushes to main branch
-            TAGS="${GHCR_IMAGE}:latest"
+            if [[ -n "${PLATFORM_TAG}" ]]; then
+              TAGS="${GHCR_IMAGE}:latest-${PLATFORM_TAG}"
+            else
+              TAGS="${GHCR_IMAGE}:latest"
+            fi
           fi
 
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
@@ -87,3 +106,38 @@ jobs:
             docker tag "${{ matrix.local_image }}" "${TAG}"
             docker push "${TAG}"
           done
+
+  merge-manifests:
+    if: github.event_name != 'pull_request'
+    needs: build-and-push
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push multi-arch manifest for pkg-drs-ros2-bridge
+        run: |
+          docker buildx imagetools create \
+            -t "ghcr.io/tier4/pkg-drs-ros2-bridge:${{ steps.tag.outputs.tag }}" \
+            "ghcr.io/tier4/pkg-drs-ros2-bridge:${{ steps.tag.outputs.tag }}-amd64" \
+            "ghcr.io/tier4/pkg-drs-ros2-bridge:${{ steps.tag.outputs.tag }}-arm64"

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -29,24 +29,10 @@ jobs:
             local_image: tier4/pkg-drs-runtime:latest
             ghcr_image: ghcr.io/tier4/pkg-drs-runtime
             needs_vcs_import: true
-            runner: ubuntu-22.04
           - build_dir: docker/calibration
             local_image: tier4/pkg-drs-calibration:latest
             ghcr_image: ghcr.io/tier4/pkg-drs-calibration
             needs_vcs_import: false
-            runner: ubuntu-22.04
-          - build_dir: docker/ros2_bridge
-            local_image: tier4/drs-ros2-bridge:latest
-            ghcr_image: ghcr.io/tier4/pkg-drs-ros2-bridge
-            needs_vcs_import: true
-            platform_tag: amd64
-            runner: ubuntu-22.04
-          - build_dir: docker/ros2_bridge
-            local_image: tier4/drs-ros2-bridge:latest
-            ghcr_image: ghcr.io/tier4/pkg-drs-ros2-bridge
-            needs_vcs_import: true
-            platform_tag: arm64
-            runner: ubuntu-24.04-arm64
 
     steps:
       - name: Check out repository
@@ -77,24 +63,15 @@ jobs:
         id: tags
         run: |
           GHCR_IMAGE="${{ matrix.ghcr_image }}"
-          PLATFORM_TAG="${{ matrix.platform_tag }}"
           TAGS=""
 
           if [[ "${{ github.event_name }}" == "release" ]]; then
             # For GitHub releases (e.g., v1.0.0)
             TAG_NAME="${{ github.event.release.tag_name }}"
-            if [[ -n "${PLATFORM_TAG}" ]]; then
-              TAGS="${GHCR_IMAGE}:${TAG_NAME}-${PLATFORM_TAG}"
-            else
-              TAGS="${GHCR_IMAGE}:${TAG_NAME}"
-            fi
+            TAGS="${GHCR_IMAGE}:${TAG_NAME}"
           else
             # For pushes to main branch
-            if [[ -n "${PLATFORM_TAG}" ]]; then
-              TAGS="${GHCR_IMAGE}:latest-${PLATFORM_TAG}"
-            else
-              TAGS="${GHCR_IMAGE}:latest"
-            fi
+            TAGS="${GHCR_IMAGE}:latest"
           fi
 
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
@@ -108,37 +85,56 @@ jobs:
             docker push "${TAG}"
           done
 
-  merge-manifests:
-    if: github.event_name != 'pull_request'
-    needs: build-and-push
-    runs-on: ubuntu-22.04
+  build-and-push-ros2-bridge:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Import external repositories
+        run: |
+          pip install vcstool
+          # Remove extraheader set by actions/checkout (uses GITHUB_TOKEN which
+          # only has access to this repo, not external private repos)
+          git config --unset-all http.https://github.com/.extraheader || true
+          ./scripts/setup_repos.sh --token "${{ secrets.DRS_PAT }}"
+
       - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Determine image tag
-        id: tag
-        run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tier4/pkg-drs-ros2-bridge
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.event_name != 'release' || !contains(github.ref_name, '-') }}
 
-      - name: Create and push multi-arch manifest for pkg-drs-ros2-bridge
-        run: |
-          docker buildx imagetools create \
-            -t "ghcr.io/tier4/pkg-drs-ros2-bridge:${{ steps.tag.outputs.tag }}" \
-            "ghcr.io/tier4/pkg-drs-ros2-bridge:${{ steps.tag.outputs.tag }}-amd64" \
-            "ghcr.io/tier4/pkg-drs-ros2-bridge:${{ steps.tag.outputs.tag }}-arm64"
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/ros2_bridge/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: COLCON_PARALLEL_WORKERS=2
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -46,7 +46,7 @@ jobs:
             ghcr_image: ghcr.io/tier4/pkg-drs-ros2-bridge
             needs_vcs_import: true
             platform_tag: arm64
-            runner: ubuntu-22.04-arm64
+            runner: ubuntu-24.04-arm64
 
     steps:
       - name: Check out repository

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -87,6 +87,7 @@ jobs:
 
   build-and-push-ros2-bridge:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -123,7 +123,7 @@ jobs:
         with:
           images: ghcr.io/tier4/pkg-drs-ros2-bridge
           tags: |
-            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
             type=raw,value=latest,enable=${{ github.event_name != 'release' || !contains(github.ref_name, '-') }}
 
       - name: Build and push multi-arch image


### PR DESCRIPTION
## Summary

- Add multi-arch (amd64 + arm64) Docker image build for `pkg-drs-ros2-bridge`
- Use `docker/build-push-action@v6` with QEMU emulation on `ubuntu-latest` (single job, no native ARM runner required)
- Use `docker/metadata-action` for tag management (`latest` / semver)
- Enable GitHub Actions cache (`type=gha`) for faster repeated builds
- `pkg-drs-runtime` and `pkg-drs-calibration` remain amd64-only, unchanged

**Background:** `docker pull pkg-drs-ros2-bridge` on ARM64 ECUs (Jetson) results in `exec format error` because the image was amd64-only. This PR fixes that by publishing a multi-arch manifest.

## Changes

`.github/workflows/docker-build-push.yaml`:

- Add dedicated `build-and-push-ros2-bridge` job
  - `docker/setup-qemu-action@v3` + `docker/setup-buildx-action@v3`
  - `platforms: linux/amd64,linux/arm64`
  - Build only on pull_request; push to GHCR on push/release events
- Add `workflow_dispatch` trigger for feature branch testing

## Test plan

- [x] Built multi-arch image to local registry (`localhost:5000`)
- [x] Confirmed both `linux/amd64` and `linux/arm64` manifests via `docker buildx imagetools inspect`
- [x] Verified `ros2 pkg list | grep ros2_bridge` passes under `docker run --platform linux/amd64`

> End-to-end verification on ARM64 ECU (Jetson) and GHCR push confirmation will be covered in the subsequent Ansible packaging PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)