### PR TITLE
chore: bump drs-api to v0.2.0, drs to v0.1.9, and restrict runtime/calibration build triggers

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -17,6 +17,7 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-22.04
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       packages: write

--- a/ansible/inventory/group_vars/all.yaml
+++ b/ansible/inventory/group_vars/all.yaml
@@ -3,12 +3,12 @@
 
 # DRS API artifact version (GitHub Releases tag without 'v' prefix; used as Docker image tag)
 # GitHub Releases URL uses v{{ drs_api_version }}; Docker image tags use {{ drs_api_version }}
-drs_api_version: 0.2.0-rc3
+drs_api_version: 0.2.0
 drs_api_gateway_image: ghcr.io/tier4/pkg-drs-api-gateway
 drs_api_dashboard_image: ghcr.io/tier4/pkg-drs-dashboard
 
 # data_recording_system artifact version (used as Docker image tag, includes 'v' prefix)
-drs_version: v0.1.8
+drs_version: v0.1.9
 drs_api_ros2bridge_image: ghcr.io/tier4/pkg-drs-ros2-bridge
 
 # DRS Configuration

--- a/ansible/inventory/group_vars/all.yaml
+++ b/ansible/inventory/group_vars/all.yaml
@@ -3,7 +3,7 @@
 
 # DRS API artifact version (GitHub Releases tag without 'v' prefix; used as Docker image tag)
 # GitHub Releases URL uses v{{ drs_api_version }}; Docker image tags use {{ drs_api_version }}
-drs_api_version: 0.2.0
+drs_api_version: 0.2.1
 drs_api_gateway_image: ghcr.io/tier4/pkg-drs-api-gateway
 drs_api_dashboard_image: ghcr.io/tier4/pkg-drs-dashboard
 

--- a/ansible/roles/netplan/handlers/main.yaml
+++ b/ansible/roles/netplan/handlers/main.yaml
@@ -1,14 +1,13 @@
-- name: Netplan apply required
+- name: Netplan config changed
   ansible.builtin.debug:
     msg: |
       ============================================
       IMPORTANT: Network configuration has changed!
       ============================================
 
-      To apply the network changes, run:
-        sudo netplan apply
+      Netplan configuration has been updated but NOT applied.
+      Network changes will take effect after the next system restart.
 
-      WARNING: This may temporarily disrupt network connectivity.
-      It's recommended to run this command when you're ready.
+      Please restart the system when ready:
+        sudo reboot
       ============================================
-  listen: netplan_apply_required

--- a/ansible/roles/netplan/tasks/main.yaml
+++ b/ansible/roles/netplan/tasks/main.yaml
@@ -12,17 +12,4 @@
     mode: 0644
   with_items: "{{ netplan_files }}"
   become: true
-  register: netplan_config_changed
-
-- name: Validate netplan configuration
-  ansible.builtin.command: netplan generate
-  become: true
-  when: netplan_config_changed.changed
-  changed_when: true
-
-- name: Schedule netplan apply for later
-  ansible.builtin.debug:
-    msg: Netplan configuration has been updated. Run 'sudo netplan apply' after Ansible completes to apply network changes.
-  when: netplan_config_changed.changed
-  changed_when: netplan_config_changed.changed
-  notify: netplan_apply_required
+  notify: Netplan config changed


### PR DESCRIPTION
## Summary

- Bump `drs_api_version` from `0.2.0-rc3` to `0.2.1` (official release; `0.2.0` had a build error where the arm64 image contained an x86-64 binary)
- Bump `drs_version` from `v0.1.8` to `v0.1.9` (official release)
- Restrict the `build-and-push` CI job (runtime/calibration Docker images) to run only on `release` events and `workflow_dispatch`, removing unnecessary builds on branch pushes and pull requests
- Remove `netplan generate` and `netplan apply` from the netplan role to prevent SSH disconnection when IP changes mid-playbook; network config now takes effect only after system restart

## Test plan

- [x] Verify Ansible deployment uses the correct `drs-api` image tag (`0.2.1`)
- [x] Verify Ansible deployment uses the correct `drs` image tag (`v0.1.9`)
- [x] Confirm that the `build-and-push` job does not trigger on PR or branch push
- [x] Confirm that `build-and-push-ros2-bridge` behavior is unchanged
- [x] Verify `drs-api-gateway` starts correctly on Jetson (arm64) with `0.2.1`
- [x] Verify netplan config is copied to `/etc/netplan/` but not applied during playbook execution
- [x] Verify network changes take effect after `sudo reboot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)