### PR TITLE
feat(ecu0): add vehicle_can_decoder to ecu0 launch

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -63,6 +63,7 @@
     "mminit",
     "navsat",
     "ncom",
+    "nodsu",
     "nebula",
     "netfilter",
     "noatime",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Data Recording System (DRS) is a high-performance sensor data recording syst
 
 ### Key Features
 
-- **Multi-Sensor Support**: Cameras (v4l2-compatible, TIER IV C1/C2/C3 cams), LiDARs/Radars (Nebula integration), GNSS/INS (OxTS)
+- **Multi-Sensor Support**: Cameras (v4l2-compatible, TIER IV C1/C2/C3 cams), LiDARs/Radars (Nebula integration), GNSS/INS (OxTS), Vehicle CAN bus (decoded via `vehicle_can_decoder`, configurable per vehicle type)
 - **Distributed Architecture**: Parallel processing across multiple ECUs (ecu0/ecu1)
 - **High-Precision Time Synchronization**: Inter-sensor synchronization via PTP (Precision Time Protocol)
 - **Hardware Trigger**: GPIO-based sensor synchronization trigger generation

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -149,6 +149,7 @@ Edit `inventory/group_vars/all.yaml` to configure:
 - CycloneDDS parameters
 - Data transfer settings
 - Time synchronization settings
+- `vehicle_can_config` — vehicle CAN decoder config name (e.g. `pacmod_v3`, `toyota_nodsu_pt_hybrid`); defaults to `pacmod_v3`
 
 ### Host-specific Variables
 

--- a/ansible/inventory/group_vars/all.yaml
+++ b/ansible/inventory/group_vars/all.yaml
@@ -24,6 +24,7 @@ has_raspi_controller: false
 has_vehicle_can: false
 has_dashboard_service: false
 lidar_driver_type: seyond
+vehicle_can_config: pacmod_v3
 
 # This option specifies the camera configuration used.
 # If using both C3 and C2 cameras: "-4 C3 -4 C2"

--- a/ansible/roles/drs/defaults/main.yaml
+++ b/ansible/roles/drs/defaults/main.yaml
@@ -11,6 +11,7 @@ drs_build_type: Release
 drs_packages:
   - drs_launch
   - proto_recorder
+  - vehicle_can_decoder
 
 # User and group for DRS installation
 drs_user: "{{ ansible_user | default('nvidia') }}"

--- a/ansible/roles/drs_config/templates/drs.env.j2
+++ b/ansible/roles/drs_config/templates/drs.env.j2
@@ -3,6 +3,7 @@ export SENSING_SYSTEM_ID={{ sensing_system_id }}
 export MODULE_ID={{ module_id }}
 export HAS_VEHICLE_CAN={{ has_vehicle_can }}
 export LIDAR_DRIVER_TYPE={{ lidar_driver_type }}
+export VEHICLE_CAN_CONFIG={{ vehicle_can_config | default('pacmod_v3') }}
 {% if ptp is defined and ptp.time_sync_type is defined %}
 export PTP_TIME_SYNC_TYPE={{ ptp.time_sync_type }}
 {% endif %}

--- a/ansible/roles/drs_recorder_service/templates/record_topics_ecu0.yaml.j2
+++ b/ansible/roles/drs_recorder_service/templates/record_topics_ecu0.yaml.j2
@@ -65,4 +65,5 @@ topics:
     max_rate: 55.0
 {% if has_vehicle_can %}
   - name: /vehicle/from_can_bus
+  - name: /vehicle/decoded_can
 {% endif %}

--- a/drs.repos
+++ b/drs.repos
@@ -52,3 +52,7 @@ repositories:
     type: git
     url: https://github.com/Seyond-Inc/inno-lidar-sdk.git
     version: e7e40ca635605447dbf8d73735706aee56b13f70  # main
+  dependencies/vehicle_can_decoder:
+    type: git
+    url: https://github.com/tier4/vehicle_can_decoder.git
+    version: dac3c1d76f0acca1c9426fc8bffb26a833336075  # main

--- a/src/drs_launch/launch/component/vehicle.launch.xml
+++ b/src/drs_launch/launch/component/vehicle.launch.xml
@@ -2,21 +2,22 @@
   <arg name="launch_driver" default="true" />
   <arg name="interface" default="can0"/>
   <arg name="receiver_interval_sec" default="0.1"/>
+  <arg name="vehicle_can_config" default="pacmod_v3"/>
 
   <group>
-    <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py">
+    <include file="$(find-pkg-share ros2_socketcan)/launch/socket_can_receiver.launch.py"
+             if="$(var launch_driver)">
       <arg name="interface" value="$(var interface)"/>
       <arg name="interval_sec" value="$(var receiver_interval_sec)"/>
-      <arg name="filters" value="025:7FF,0B4:7FF,0AA:7FF,024:7FF,0A6:7FF,230:7FF,245:7FF,361:7FF,260:7FF,1C4:7FF,3BC:7FF,127:7FF"/>
     </include>
 
-    <!-- TODO: Implement vehicle node -->
-    <!--
-    <node pkg="xxxx" exec="xxxx_node" name="xxxx" if="$(var launch_driver)">
-      <remap from="~/input/frame" to="from_can_bus"/>
-      <remap from="~/output/velocity" to="velocity"/>
-      <remap from="~/output/steer" to="steer"/>
-    </node>
-    -->
+    <include file="$(find-pkg-share vehicle_can_decoder)/launch/vehicle_can_decoder.launch.py"
+             if="$(var launch_driver)">
+      <arg name="schema_file"
+           value="$(find-pkg-share vehicle_can_decoder)/config/vehicle_schema.yaml"/>
+      <arg name="config_file"
+           value="$(find-pkg-share vehicle_can_decoder)/config/$(var vehicle_can_config).yaml"/>
+      <arg name="dbc_file" value="/opt/drs/config/vehicle.dbc"/>
+    </include>
   </group>
 </launch>

--- a/src/drs_launch/launch/drs.launch.xml
+++ b/src/drs_launch/launch/drs.launch.xml
@@ -14,6 +14,8 @@
        description="Type of LiDAR driver to use: nebula or seyond"/>
   <arg name="has_vehicle_can" default="$(env HAS_VEHICLE_CAN)"
        description="Should be true when vehicle CAN is available"/>
+  <arg name="vehicle_can_config" default="$(env VEHICLE_CAN_CONFIG pacmod_v3)"
+       description="Vehicle CAN decoder config: pacmod_v3 or toyota_nodsu_pt_hybrid"/>
 
   <include file="$(find-pkg-share drs_launch)/launch/drs_ecu$(var drs_ecu_id).launch.xml">
     <arg name="vehicle_id" value="$(var vehicle_id)"/>
@@ -23,6 +25,7 @@
     <arg name="param_root_dir" value="$(var param_root_dir)"/>
     <arg name="lidar_driver_type" value="$(var lidar_driver_type)"/>
     <arg name="has_vehicle_can" value="$(var has_vehicle_can)"/>
+    <arg name="vehicle_can_config" value="$(var vehicle_can_config)"/>
   </include>
 
 </launch>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -6,6 +6,7 @@
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
   <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"/>
   <arg name="has_vehicle_can" default="false"/>
+  <arg name="vehicle_can_config" default="$(env VEHICLE_CAN_CONFIG pacmod_v3)"/>
 
   <group>
     <push-ros-namespace namespace="sensing"/>
@@ -101,6 +102,7 @@
     <push-ros-namespace namespace="vehicle"/>
     <include file="$(find-pkg-share drs_launch)/launch/component/vehicle.launch.xml">
       <arg name="launch_driver" value="$(var live_sensor)"/>
+      <arg name="vehicle_can_config" value="$(var vehicle_can_config)"/>
     </include>
   </group>
 

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -3,6 +3,7 @@
   <arg name="live_sensor" default="true"/>
   <arg name="publish_pointcloud" default="false"/>
   <arg name="has_vehicle_can" default="false"/>
+  <arg name="vehicle_can_config" default="pacmod_v3"/>
   <arg name="publish_tf" default="true"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
   <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"/>


### PR DESCRIPTION
## Summary

Integrates `vehicle_can_decoder` ROS 2 node into the ecu0 launch chain. Raw CAN frames
from `ros2_socketcan` are now decoded into structured vehicle signal topics
(`/vehicle/decoded_can`) and recorded alongside the raw `/vehicle/from_can_bus` topic.

**Launch configuration**
- `drs.repos`: add `vehicle_can_decoder` at `dac3c1d` (deps `dbcppp`/`exprtk` handled by CMake FetchContent)
- `ansible/roles/drs/defaults/main.yaml`: add `vehicle_can_decoder` to `drs_packages` for `colcon --packages-up-to`
- `ansible/roles/drs_config/templates/drs.env.j2` + `ansible/inventory/group_vars/all.yaml`: thread `VEHICLE_CAN_CONFIG` env var (default: `pacmod_v3`)
- `src/drs_launch/launch/drs.launch.xml` → `drs_ecu0.launch.xml` → `vehicle.launch.xml`: arg chain for `vehicle_can_config`
- `src/drs_launch/launch/component/vehicle.launch.xml`: replace TODO with real include; remove hardcoded CAN ID filters (D2 decision); add `if="$(var launch_driver)"` guard to `socket_can_receiver` for replay consistency (D3)
- `src/drs_launch/launch/drs_ecu1.launch.xml`: declare `vehicle_can_config` arg to prevent launch error when `DRS_ECU_ID=1`
- `ansible/roles/drs_recorder_service/templates/record_topics_ecu0.yaml.j2`: record `/vehicle/decoded_can` under `has_vehicle_can` gate

## Documentation

- `README.md`: added Vehicle CAN bus to Multi-Sensor Support key features — notes `vehicle_can_decoder` integration and per-vehicle-type configurability
- `ansible/README.md`: added `vehicle_can_config` to the Global Variables list — documents the `pacmod_v3` default and alternative values

## Test plan

- [ ] `ros2 launch drs_launch drs.launch.xml has_vehicle_can:=true` starts without errors on ecu0
- [ ] `ros2 topic echo /vehicle/decoded_can` shows SignalGroup messages when CAN bus is active
- [ ] `/vehicle/decoded_can` topic appears in recorded bag alongside `/vehicle/from_can_bus`
- [ ] `vehicle_can_config:=toyota_nodsu_pt_hybrid` override works from the launch CLI
- [ ] Verify `DRS_ECU_ID=1` launch does not error on undeclared `vehicle_can_config` arg

🤖 Generated with [Claude Code](https://claude.com/claude-code)
