### PR TITLE
feat(launch): add launch_cameras and launch_lidars args for selective sensor startup

### DIFF
--- a/src/drs_launch/launch/drs.launch.xml
+++ b/src/drs_launch/launch/drs.launch.xml
@@ -14,6 +14,10 @@
        description="Type of LiDAR driver to use: nebula or seyond"/>
   <arg name="has_vehicle_can" default="$(env HAS_VEHICLE_CAN)"
        description="Should be true when vehicle CAN is available"/>
+  <arg name="launch_cameras" default="all"
+       description="Comma-separated camera IDs to launch, or 'all' (e.g. '0,1,2,3' or '0')"/>
+  <arg name="launch_lidars" default="all"
+       description="Comma-separated LiDAR positions to launch, or 'all' (e.g. 'front,right' or 'front')"/>
 
   <include file="$(find-pkg-share drs_launch)/launch/drs_ecu$(var drs_ecu_id).launch.xml">
     <arg name="vehicle_id" value="$(var vehicle_id)"/>
@@ -23,6 +27,8 @@
     <arg name="param_root_dir" value="$(var param_root_dir)"/>
     <arg name="lidar_driver_type" value="$(var lidar_driver_type)"/>
     <arg name="has_vehicle_can" value="$(var has_vehicle_can)"/>
+    <arg name="launch_cameras" value="$(var launch_cameras)"/>
+    <arg name="launch_lidars" value="$(var launch_lidars)"/>
   </include>
 
 </launch>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -14,7 +14,7 @@
     <group>
       <push-ros-namespace namespace="camera"/>
 
-      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '0' in '$(var launch_cameras)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '0' in '$(var launch_cameras)'.replace(' ','').split(',')&quot;)">
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
           <arg name="camera_id" value="0"/>
           <arg name="param_root_dir" value="$(var param_root_dir)"/>
@@ -24,7 +24,7 @@
         </include>
       </group>
 
-      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '1' in '$(var launch_cameras)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '1' in '$(var launch_cameras)'.replace(' ','').split(',')&quot;)">
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
           <arg name="camera_id" value="1"/>
           <arg name="param_root_dir" value="$(var param_root_dir)"/>
@@ -34,7 +34,7 @@
         </include>
       </group>
 
-      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '2' in '$(var launch_cameras)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '2' in '$(var launch_cameras)'.replace(' ','').split(',')&quot;)">
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
           <arg name="camera_id" value="2"/>
           <arg name="param_root_dir" value="$(var param_root_dir)"/>
@@ -44,7 +44,7 @@
         </include>
       </group>
 
-      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '3' in '$(var launch_cameras)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '3' in '$(var launch_cameras)'.replace(' ','').split(',')&quot;)">
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
           <arg name="camera_id" value="3"/>
           <arg name="param_root_dir" value="$(var param_root_dir)"/>
@@ -57,7 +57,7 @@
 
     <group>
       <push-ros-namespace namespace="lidar"/>
-      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'front' in '$(var launch_lidars)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'front' in '$(var launch_lidars)'.replace(' ','').split(',')&quot;)">
         <push-ros-namespace namespace="front"/>
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="front"/>
@@ -73,7 +73,7 @@
         </include>
       </group>
 
-      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'right' in '$(var launch_lidars)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'right' in '$(var launch_lidars)'.replace(' ','').split(',')&quot;)">
         <push-ros-namespace namespace="right"/>
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="right"/>

--- a/src/drs_launch/launch/drs_ecu0.launch.xml
+++ b/src/drs_launch/launch/drs_ecu0.launch.xml
@@ -6,48 +6,58 @@
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
   <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"/>
   <arg name="has_vehicle_can" default="false"/>
+  <arg name="launch_cameras" default="0,1,2,3"/>
+  <arg name="launch_lidars" default="front,right"/>
 
   <group>
     <push-ros-namespace namespace="sensing"/>
     <group>
       <push-ros-namespace namespace="camera"/>
 
-      <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
-        <arg name="camera_id" value="0"/>
-        <arg name="param_root_dir" value="$(var param_root_dir)"/>
-        <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="false"/>
-        <arg name="startup_delay" value="0.0"/>
-      </include>
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '0' in '$(var launch_cameras)'.split(',')&quot;)">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
+          <arg name="camera_id" value="0"/>
+          <arg name="param_root_dir" value="$(var param_root_dir)"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="set_readout_delay" value="false"/>
+          <arg name="startup_delay" value="0.0"/>
+        </include>
+      </group>
 
-      <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
-        <arg name="camera_id" value="1"/>
-        <arg name="param_root_dir" value="$(var param_root_dir)"/>
-        <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="false"/>
-        <arg name="startup_delay" value="0.1"/>
-      </include>
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '1' in '$(var launch_cameras)'.split(',')&quot;)">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
+          <arg name="camera_id" value="1"/>
+          <arg name="param_root_dir" value="$(var param_root_dir)"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="set_readout_delay" value="false"/>
+          <arg name="startup_delay" value="0.1"/>
+        </include>
+      </group>
 
-      <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
-        <arg name="camera_id" value="2"/>
-        <arg name="param_root_dir" value="$(var param_root_dir)"/>
-        <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="true"/>
-        <arg name="startup_delay" value="0.2"/>
-      </include>
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '2' in '$(var launch_cameras)'.split(',')&quot;)">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
+          <arg name="camera_id" value="2"/>
+          <arg name="param_root_dir" value="$(var param_root_dir)"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="set_readout_delay" value="true"/>
+          <arg name="startup_delay" value="0.2"/>
+        </include>
+      </group>
 
-      <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
-        <arg name="camera_id" value="3"/>
-        <arg name="param_root_dir" value="$(var param_root_dir)"/>
-        <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="true"/>
-        <arg name="startup_delay" value="0.3"/>
-      </include>
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '3' in '$(var launch_cameras)'.split(',')&quot;)">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
+          <arg name="camera_id" value="3"/>
+          <arg name="param_root_dir" value="$(var param_root_dir)"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="set_readout_delay" value="true"/>
+          <arg name="startup_delay" value="0.3"/>
+        </include>
+      </group>
     </group>
 
     <group>
       <push-ros-namespace namespace="lidar"/>
-      <group>
+      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'front' in '$(var launch_lidars)'.split(',')&quot;)">
         <push-ros-namespace namespace="front"/>
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="front"/>
@@ -63,7 +73,7 @@
         </include>
       </group>
 
-      <group>
+      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'right' in '$(var launch_lidars)'.split(',')&quot;)">
         <push-ros-namespace namespace="right"/>
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="right"/>

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -6,48 +6,58 @@
   <arg name="publish_tf" default="true"/>
   <arg name="param_root_dir" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)"/>
   <arg name="lidar_driver_type" default="$(env LIDAR_DRIVER_TYPE seyond)"/>
+  <arg name="launch_cameras" default="4,5,6,7"/>
+  <arg name="launch_lidars" default="rear,left"/>
 
   <group>
     <push-ros-namespace namespace="sensing"/>
     <group>
       <push-ros-namespace namespace="camera"/>
 
-      <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
-        <arg name="camera_id" value="4"/>
-        <arg name="param_root_dir" value="$(var param_root_dir)"/>
-        <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="false"/>
-        <arg name="startup_delay" value="0.0"/>
-      </include>
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '4' in '$(var launch_cameras)'.split(',')&quot;)">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
+          <arg name="camera_id" value="4"/>
+          <arg name="param_root_dir" value="$(var param_root_dir)"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="set_readout_delay" value="false"/>
+          <arg name="startup_delay" value="0.0"/>
+        </include>
+      </group>
 
-      <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
-        <arg name="camera_id" value="5"/>
-        <arg name="param_root_dir" value="$(var param_root_dir)"/>
-        <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="false"/>
-        <arg name="startup_delay" value="0.1"/>
-      </include>
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '5' in '$(var launch_cameras)'.split(',')&quot;)">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
+          <arg name="camera_id" value="5"/>
+          <arg name="param_root_dir" value="$(var param_root_dir)"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="set_readout_delay" value="false"/>
+          <arg name="startup_delay" value="0.1"/>
+        </include>
+      </group>
 
-      <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
-        <arg name="camera_id" value="6"/>
-        <arg name="param_root_dir" value="$(var param_root_dir)"/>
-        <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="true"/>
-        <arg name="startup_delay" value="0.2"/>
-      </include>
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '6' in '$(var launch_cameras)'.split(',')&quot;)">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
+          <arg name="camera_id" value="6"/>
+          <arg name="param_root_dir" value="$(var param_root_dir)"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="set_readout_delay" value="true"/>
+          <arg name="startup_delay" value="0.2"/>
+        </include>
+      </group>
 
-      <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
-        <arg name="camera_id" value="7"/>
-        <arg name="param_root_dir" value="$(var param_root_dir)"/>
-        <arg name="live_sensor" value="$(var live_sensor)"/>
-        <arg name="set_readout_delay" value="true"/>
-        <arg name="startup_delay" value="0.3"/>
-      </include>
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '7' in '$(var launch_cameras)'.split(',')&quot;)">
+        <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
+          <arg name="camera_id" value="7"/>
+          <arg name="param_root_dir" value="$(var param_root_dir)"/>
+          <arg name="live_sensor" value="$(var live_sensor)"/>
+          <arg name="set_readout_delay" value="true"/>
+          <arg name="startup_delay" value="0.3"/>
+        </include>
+      </group>
     </group>
 
     <group>
       <push-ros-namespace namespace="lidar"/>
-      <group>
+      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'rear' in '$(var launch_lidars)'.split(',')&quot;)">
         <push-ros-namespace namespace="rear"/>
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="rear"/>
@@ -63,7 +73,7 @@
         </include>
       </group>
 
-      <group>
+      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'left' in '$(var launch_lidars)'.split(',')&quot;)">
         <push-ros-namespace namespace="left"/>
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="left"/>

--- a/src/drs_launch/launch/drs_ecu1.launch.xml
+++ b/src/drs_launch/launch/drs_ecu1.launch.xml
@@ -14,7 +14,7 @@
     <group>
       <push-ros-namespace namespace="camera"/>
 
-      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '4' in '$(var launch_cameras)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '4' in '$(var launch_cameras)'.replace(' ','').split(',')&quot;)">
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
           <arg name="camera_id" value="4"/>
           <arg name="param_root_dir" value="$(var param_root_dir)"/>
@@ -24,7 +24,7 @@
         </include>
       </group>
 
-      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '5' in '$(var launch_cameras)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '5' in '$(var launch_cameras)'.replace(' ','').split(',')&quot;)">
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
           <arg name="camera_id" value="5"/>
           <arg name="param_root_dir" value="$(var param_root_dir)"/>
@@ -34,7 +34,7 @@
         </include>
       </group>
 
-      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '6' in '$(var launch_cameras)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '6' in '$(var launch_cameras)'.replace(' ','').split(',')&quot;)">
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
           <arg name="camera_id" value="6"/>
           <arg name="param_root_dir" value="$(var param_root_dir)"/>
@@ -44,7 +44,7 @@
         </include>
       </group>
 
-      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '7' in '$(var launch_cameras)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_cameras)' or '7' in '$(var launch_cameras)'.replace(' ','').split(',')&quot;)">
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_camera.launch.py">
           <arg name="camera_id" value="7"/>
           <arg name="param_root_dir" value="$(var param_root_dir)"/>
@@ -57,7 +57,7 @@
 
     <group>
       <push-ros-namespace namespace="lidar"/>
-      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'rear' in '$(var launch_lidars)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'rear' in '$(var launch_lidars)'.replace(' ','').split(',')&quot;)">
         <push-ros-namespace namespace="rear"/>
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="rear"/>
@@ -73,7 +73,7 @@
         </include>
       </group>
 
-      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'left' in '$(var launch_lidars)'.split(',')&quot;)">
+      <group if="$(eval &quot;'all' == '$(var launch_lidars)' or 'left' in '$(var launch_lidars)'.replace(' ','').split(',')&quot;)">
         <push-ros-namespace namespace="left"/>
         <include file="$(find-pkg-share drs_launch)/launch/component/drs_$(var lidar_driver_type).launch.xml">
           <arg name="lidar_position" value="left"/>


### PR DESCRIPTION
## Summary

- Add `launch_cameras` and `launch_lidars` arguments to `drs.launch.xml`, `drs_ecu0.launch.xml`, and `drs_ecu1.launch.xml` to support launching only specific cameras and LiDARs (e.g. for calibration)
- Accepts comma-separated camera IDs (e.g. `0` or `0,1,2,3`) and LiDAR positions (e.g. `front` or `front,right`), or `all` to launch every sensor on the selected ECU
- Defaults: `all` in `drs.launch.xml`; ECU-specific full lists (`0,1,2,3` / `front,right` for ECU0, `4,5,6,7` / `rear,left` for ECU1) when launched directly

**Example usage (calibration):**
```bash
# ECU0: camera 0 + front LiDAR only
ros2 launch drs_launch drs.launch.xml launch_cameras:=0 launch_lidars:=front

# Normal startup (all sensors)
ros2 launch drs_launch drs.launch.xml 
```

## Test plan

Verified on HILS environment:

- [x] ECU0: camera 0 + front LiDAR only (`launch_cameras:=0 launch_lidars:=front`)
- [x] ECU0: camera 3 + right LiDAR only (`launch_cameras:=3 launch_lidars:=right`)
- [x] ECU1: camera 4 + rear LiDAR only (`launch_cameras:=4 launch_lidars:=rear`)
- [x] Normal startup with all sensors (default args, no regression)

dashboard example(camera 4 + rear LiDAR only)
<img width="743" height="591" alt="Screenshot from 2026-06-24 15-48-01" src="https://github.com/user-attachments/assets/6b346954-5762-470b-852f-e7d8453ad3aa" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)