### PR TITLE
docs: align drs_sensor_service and multi_transform_publisher READMEs with reality

### DIFF
--- a/ansible/roles/drs_sensor_service/README.md
+++ b/ansible/roles/drs_sensor_service/README.md
@@ -1,60 +1,53 @@
-# DRS Launch Service Role
+# DRS Sensor Service Role
 
-This Ansible role configures a systemd service to launch the DRS (Data Recording System) ROS 2 nodes.
+This Ansible role deploys the DRS sensor nodes as a systemd service (`drs-sensor.service`) that runs `ros2 launch drs_launch drs.launch.xml` on boot.
 
 ## Features
 
-- Systemd service management for ROS 2 launch files
-- Full journald integration for centralized logging
-- Resource limits and security hardening
+- Systemd service management for the DRS sensor launch entry point
+- Journald integration for centralized logging
 - Automatic restart on failure
-- Environment variable configuration
+- Optional custom parameter directory support
+- Real-time scheduling and memory-locking limits for the sensor trigger
 
 ## Role Variables
 
-### Required Variables
+### User Configuration
 
-- `drs_user`: User to run the service (default: ansible_user or 'nvidia')
-- `drs_group`: Group for the service (default: ansible_user or 'nvidia')
+- `drs_user`: User to run the service (default: `ansible_user` or `nvidia`)
+- `drs_group`: Group for the service (default: `ansible_user` or `nvidia`)
 
-### Optional Variables
+### DRS Paths
 
-- `drs_install_dir`: DRS installation directory (default: /opt/drs/install)
-- `ros_domain_id`: ROS domain ID (default: 0)
-- `ros_localhost_only`: Restrict ROS to localhost (default: 0)
-- `rmw_implementation`: RMW implementation (default: rmw_cyclonedds_cpp)
-- `drs_launch_args`: Additional launch arguments (default: "")
-- `drs_device_access`: List of devices to allow access (default: [])
-- `drs_extra_env`: Dictionary of extra environment variables (default: {})
+- `drs_install_dir`: DRS installation directory (default: `/opt/drs/install`)
 
-### Logging Configuration
+### Parameter Configuration
 
-- `drs_log_priority`: Log priority level (default: info)
-- `drs_log_rate_limit_interval`: Rate limit interval (default: 30s)
-- `drs_log_rate_limit_burst`: Rate limit burst (default: 1000)
+- `drs_use_custom_params`: If true, the launch script passes `param_root_dir:={{ drs_param_root_dir }}` to `drs.launch.xml`, and the default parameters shipped with `individual_params` are copied into `drs_param_root_dir` when the directory does not exist yet (default: `true`)
+- `drs_param_root_dir`: Root directory for sensor parameters (default: `/opt/drs/config/params`)
 
-## Dependencies
+### Service Limits
 
-- drs
-- drs_config
-- ros2
-- cyclonedds
+- `sensor_trigger_rtprio`: Real-time priority limit (`LimitRTPRIO`) of the service (default: `85`)
+- `sensor_trigger_memlock`: Locked memory limit (`LimitMEMLOCK`) of the service (default: `infinity`)
+
+## What This Role Does
+
+- Creates `/opt/drs/service/drs_sensor/`
+- Seeds `drs_param_root_dir` with the default parameters from `individual_params` if missing (only when `drs_use_custom_params` is true)
+- Deploys `/opt/drs/service/drs_sensor/launch.sh`, which sources `/opt/drs/config/drs.env`, the ROS 2 Humble setup, and the DRS install setup, then launches `drs_launch drs.launch.xml`
+- Deploys, enables, and starts `/etc/systemd/system/drs-sensor.service`
 
 ## Example Playbook
 
 ```yaml
-- hosts: drs_nodes
+- hosts: drs_ecus
   roles:
-    - role: drs_launch_service
+    - role: drs_sensor_service
       vars:
         drs_user: nvidia
-        ros_domain_id: 42
-        drs_launch_args: "use_sim_time:=false"
-        drs_device_access:
-          - "/dev/can*"
-          - "/dev/ttyUSB*"
-        drs_extra_env:
-          CUSTOM_VAR: "value"
+        drs_use_custom_params: true
+        drs_param_root_dir: /opt/drs/config/params
 ```
 
 ## Service Management
@@ -63,27 +56,27 @@ This Ansible role configures a systemd service to launch the DRS (Data Recording
 
 ```bash
 # Real-time logs
-journalctl -u drs-launch -f
+journalctl -u drs-sensor -f
 
 # Logs from the last hour
-journalctl -u drs-launch --since "1 hour ago"
+journalctl -u drs-sensor --since "1 hour ago"
 
 # Logs with specific priority
-journalctl -u drs-launch -p err
+journalctl -u drs-sensor -p err
 ```
 
 ### Service control
 
 ```bash
 # Check status
-systemctl status drs-launch
+systemctl status drs-sensor
 
 # Start/stop/restart
-sudo systemctl start drs-launch
-sudo systemctl stop drs-launch
-sudo systemctl restart drs-launch
+sudo systemctl start drs-sensor
+sudo systemctl stop drs-sensor
+sudo systemctl restart drs-sensor
 
 # Enable/disable at boot
-sudo systemctl enable drs-launch
-sudo systemctl disable drs-launch
+sudo systemctl enable drs-sensor
+sudo systemctl disable drs-sensor
 ```

--- a/src/multi_transform_publisher/README.md
+++ b/src/multi_transform_publisher/README.md
@@ -10,6 +10,8 @@ This node replaces multiple `periodic_transform_publisher` instances with a sing
 
 - `config_file` (string, required): Path to YAML configuration file containing transform definitions
 - `publish_camera_optical_link` (bool, default: true): Whether to automatically publish camera_link to camera_optical_link transforms
+- `periodic_publish` (bool, default: false): Whether to publish transforms periodically instead of as static transforms
+- `publish_period` (double, default: 0.1): Period in seconds for periodic publishing (only used when `periodic_publish` is true)
 
 ## YAML Configuration Format
 
@@ -70,24 +72,12 @@ When `publish_camera_optical_link` is true, the node automatically creates trans
 
 ```xml
 <include file="$(find-pkg-share drs_launch)/launch/component/multi_transform_publisher.launch.xml">
-  <arg name="config_file" value="$(find-pkg-share individual_params)/config/default/multi_tf_static.yaml"/>
+  <arg name="param_root_dir" value="$(find-pkg-share individual_params)/config/default"/>
   <arg name="publish_camera_optical_link" value="true"/>
 </include>
 ```
 
-### Component Launch
-
-```xml
-<!-- First create a component container -->
-<node_container pkg="rclcpp_components" exec="component_container" name="my_container" namespace="/" />
-
-<!-- Then load the multi_transform_publisher component -->
-<include file="$(find-pkg-share drs_launch)/launch/component/multi_transform_publisher_component.launch.py">
-  <arg name="container_name" value="/my_container"/>
-  <arg name="config_file" value="$(find-pkg-share individual_params)/config/default/multi_tf_static.yaml"/>
-  <arg name="publish_camera_optical_link" value="true"/>
-</include>
-```
+The launch file passes `$(var param_root_dir)/multi_tf_static.yaml` to the node's `config_file` parameter.
 
 ### Command Line
 


### PR DESCRIPTION
## Description

Fix two stale READMEs whose contents no longer match the implementation:

- `ansible/roles/drs_sensor_service/README.md` described a `drs_launch_service` role managing a `drs-launch` unit, and documented variables (`drs_launch_args`, `drs_device_access`, `drs_extra_env`, `drs_log_*`) that the role does not implement. Rewritten to describe the actual `drs_sensor_service` role: the `drs-sensor.service` unit, the real variables (`drs_user`, `drs_group`, `drs_install_dir`, `drs_use_custom_params`, `drs_param_root_dir`, `sensor_trigger_rtprio`, `sensor_trigger_memlock`), what the role deploys, and correct `journalctl`/`systemctl` examples.
- `src/multi_transform_publisher/README.md` referenced a nonexistent `component/multi_transform_publisher_component.launch.py` and used a `config_file` launch argument that the actual launch file does not accept (it takes `param_root_dir`). The component launch example is removed, the standalone example now uses `param_root_dir`, and the Parameters section documents all four node parameters (`periodic_publish` and `publish_period` were missing).

## Tests performed

- Compared `ansible/roles/drs_sensor_service/README.md` against `defaults/main.yaml`, `tasks/main.yaml`, and `templates/drs-sensor.service.jinja2` in the same role.
- Compared `src/multi_transform_publisher/README.md` against `src/drs_launch/launch/component/multi_transform_publisher.launch.xml` and the `declare_parameter` calls in `src/multi_transform_publisher/src/multi_transform_publisher.cpp`.
- `pre-commit run --all-files` passes (markdownlint included).

## Effects on system behavior

Not applicable; documentation-only change.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/