### PR TITLE
chore(repos): remove bag_converter from drs.repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ compile_commands.json
 .cache/
 
 # ── External repositories (managed via vcs import) ──────────
-src/bag_converter/
 src/drs-api/
 src/proto_recorder
 

--- a/drs.repos
+++ b/drs.repos
@@ -36,11 +36,3 @@ repositories:
     type: git
     url: https://github.com/tier4/drs-api.git
     version: 89e49cbab4ba19f3c698057e1b35da04cccf8f27  # develop
-  bag_converter:
-    type: git
-    url: https://github.com/tier4/bag_converter.git
-    version: 2413e30400a0845c4390af7243093ba3160ab3be  # main
-  bag_converter/src/seyond_decoder/src/seyond_sdk:
-    type: git
-    url: https://github.com/Seyond-Inc/inno-lidar-sdk.git
-    version: e7e40ca635605447dbf8d73735706aee56b13f70  # main


### PR DESCRIPTION
## Summary

Remove the `bag_converter` repository and its nested `seyond_sdk` (inno-lidar-sdk) import from `drs.repos`, decoupling this offline post-processing tool from the DRS workspace. Also drops the now-unneeded `src/bag_converter/` entry from `.gitignore`.

## Details

`bag_converter` is a standalone offline tool (Docker image + wrapper script) that decodes recorded mcap files. A full-workspace audit confirmed **nothing in this repository depends on it**:

- No launch file, node declaration, `package.xml`, ansible role/task, or Dockerfile references `bag_converter` or any of its packages (`bag_manipulate`, `nebula_decoder`, `nebula_drs`, `seyond_decoder`, `seyond_nebula_decoder`).
- Build targets (`drs_launch`, `proto_recorder`, `ros2_bridge`) do not depend on it — checked in `scripts/build.sh`, `docker/runtime/Dockerfile`, and the ansible `drs` role (`drs_packages`).
- The runtime `seyond` LiDAR driver defines its own `SeyondScan`/`SeyondPacket` messages; its own `seyond_sdk` import (`dependencies/seyond_ros_driver/.../seyond_sdk`) stays untouched. Only the duplicate import under `bag_converter/` is removed.

## How to verify

- `grep -R "bag_converter\|bag_manipulate\|nebula_decoder\|seyond_decoder"` hits nothing in this repository outside the removed entries.
- `colcon list --packages-up-to drs_launch proto_recorder ros2_bridge` resolves successfully.
- `pre-commit run --all-files` passes.

## Improvements

- `vcs import` (`scripts/setup_repos.sh`, CI `docker-build-push`, ansible `drs` role) no longer clones `bag_converter`, shortening setup.
- `rosdep` no longer tries to resolve bag_converter's unsatisfiable `nebula_common`/`nebula_decoders` dependencies during deployment.

## Limitations

- Pre-existing local checkouts (`src/bag_converter/`) and stale `build/` artifacts are not removed by this commit; delete them manually if present.