### PR TITLE
chore(scripts): restore aggregate_calibration_files.py and backup_drs_config.py

### DIFF
--- a/scripts/aggregate_calibration_files.py
+++ b/scripts/aggregate_calibration_files.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+import yaml
+import sys
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Any, Optional
+
+def load_yaml_file(filepath: Path) -> Optional[Dict[str, Any]]:
+    """Load a YAML file
+
+    Args:
+        filepath: Path to the YAML file
+
+    Returns:
+        Dictionary of YAML data, None on error
+    """
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            return yaml.safe_load(f)
+    except Exception as e:
+        logging.error(f"Error reading {filepath}: {e}")
+        return None
+
+def save_yaml_file(data: Dict[str, Any], filepath: Path) -> bool:
+    """Save data to a YAML file
+
+    Args:
+        data: Data to save
+        filepath: Path to save the file
+
+    Returns:
+        True on success, False on failure
+    """
+    try:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+        return True
+    except Exception as e:
+        logging.error(f"Error saving to {filepath}: {e}")
+        return False
+
+def merge_yaml_data(base_data: Optional[Dict], new_data: Optional[Dict]) -> Dict:
+    """Recursively merge YAML data
+
+    Args:
+        base_data: Base data dictionary
+        new_data: Data to merge
+
+    Returns:
+        Merged data dictionary
+    """
+    if base_data is None:
+        return new_data or {}
+    if new_data is None:
+        return base_data
+
+    if isinstance(new_data, dict) and isinstance(base_data, dict):
+        result = base_data.copy()
+        for key, value in new_data.items():
+            if key in result:
+                result[key] = merge_yaml_data(result[key], value)
+            else:
+                result[key] = value
+        return result
+
+    return new_data
+
+class YamlAggregator:
+    """Class for aggregating YAML files"""
+
+    DEFAULT_OUTPUT = "multi_tf_static.yaml"
+
+    BASE_LINK_DATA = {
+        "base_link": {
+            "drs_base_link": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0,
+                "roll": 0.0,
+                "pitch": 0.0,
+                "yaw": 0.0
+            }
+        }
+    }
+
+
+    def __init__(self, input_dir: str, output_file: str = DEFAULT_OUTPUT):
+        self.input_path = Path(input_dir)
+        self.output_path = Path(output_file)  # Store output path directly
+        self.result_data = {}
+        self.child_key_sources: Dict[str, Dict[str, List[str]]] = {}  # Track sources of child keys per parent key
+
+    def validate_input_directory(self) -> bool:
+        """Validate the input directory"""
+        if not self.input_path.exists():
+            logging.error(f"Directory {self.input_path} does not exist")
+            return False
+        if not self.input_path.is_dir():
+            logging.error(f"{self.input_path} is not a directory")
+            return False
+        return True
+
+    def get_yaml_files(self) -> List[Path]:
+        """Get YAML files to aggregate"""
+        # Exclude output file only if it's in the input directory
+        output_name = self.output_path.name if self.output_path.parent == self.input_path else None
+        return sorted([
+            f for f in self.input_path.glob("*.yaml")
+            if f.name != output_name and f.is_file()
+        ])
+
+    def detect_duplicate_child_keys(self, data: Dict, filename: str, parent_key: str = "") -> None:
+        """Detect duplicate child keys under parent keys
+
+        Args:
+            data: Data to check
+            filename: Source filename
+            parent_key: Parent key name
+        """
+        if not isinstance(data, dict):
+            return
+
+        for key, value in data.items():
+            # Treat top-level keys as parent keys
+            if not parent_key:  # At top level
+                if isinstance(value, dict):
+                    # Track child keys under this parent key
+                    if key not in self.child_key_sources:
+                        self.child_key_sources[key] = {}
+
+                    for child_key in value.keys():
+                        if child_key not in self.child_key_sources[key]:
+                            self.child_key_sources[key][child_key] = []
+                        self.child_key_sources[key][child_key].append(filename)
+
+                    # Process recursively (limit nesting depth to 2 levels)
+                    self.detect_duplicate_child_keys(value, filename, key)
+
+    def report_duplicates(self) -> None:
+        """Report warnings for duplicate child keys"""
+        has_duplicates = False
+        warnings = []
+
+        for parent_key, children in sorted(self.child_key_sources.items()):
+            for child_key, sources in sorted(children.items()):
+                if len(sources) > 1:
+                    has_duplicates = True
+                    warnings.append((parent_key, child_key, sources))
+
+        if has_duplicates:
+            logging.warning("Duplicate child keys detected:")
+            for parent_key, child_key, sources in warnings:
+                logging.warning(f"  Under '{parent_key}': key '{child_key}' found in multiple files:")
+                for source in sorted(set(sources)):
+                    count = sources.count(source)
+                    if count > 1:
+                        logging.warning(f"    - {source} ({count} times)")
+                    else:
+                        logging.warning(f"    - {source}")
+
+    def load_and_merge_files(self, yaml_files: List[Path]) -> None:
+        """Load and merge YAML files"""
+        self.result_data = merge_yaml_data({}, self.BASE_LINK_DATA)
+        self.child_key_sources.clear()
+
+        # Also track keys from BASE_LINK_DATA
+        self.detect_duplicate_child_keys(self.BASE_LINK_DATA, "<built-in>")
+
+        for yaml_file in yaml_files:
+            logging.info(f"Processing: {yaml_file.name}")
+            data = load_yaml_file(yaml_file)
+            if data:
+                # Detect duplicate child keys
+                self.detect_duplicate_child_keys(data, yaml_file.name)
+                self.result_data = merge_yaml_data(self.result_data, data)
+                logging.info(f"  - {data}")
+
+        # Display duplicate key warnings
+        self.report_duplicates()
+
+
+    def write_output_file(self) -> bool:
+        """Write results to output file"""
+        output_path = self.output_path
+
+        try:
+            with open(output_path, 'w', encoding='utf-8') as f:
+                # Write header comments with timestamp
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                header_comments = [
+                    "# Multi TF Static Publisher Configuration",
+                    "# This file combines all calibration transforms for the DRS system",
+                    f"# Generated: {timestamp}",
+                    ""
+                ]
+                for comment in header_comments:
+                    f.write(f"{comment}\n")
+
+                # Write all data as a single YAML document
+                yaml.dump(
+                    self.result_data,
+                    f,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True
+                )
+
+            print(f"Output saved to: {output_path}")
+            logging.info(f"Output saved to: {output_path}")
+            return True
+
+        except Exception as e:
+            logging.error(f"Error writing output file: {e}")
+            return False
+
+    def aggregate(self) -> bool:
+        """Execute aggregation process"""
+        if not self.validate_input_directory():
+            return False
+
+        yaml_files = self.get_yaml_files()
+        if not yaml_files:
+            logging.warning(f"No YAML files found in {self.input_path}")
+            return False
+
+        print(f"Found {len(yaml_files)} YAML files to aggregate")
+        logging.info(f"Found {len(yaml_files)} YAML files:")
+        for f in yaml_files:
+            logging.info(f"  - {f.name}")
+
+        self.load_and_merge_files(yaml_files)
+        return self.write_output_file()
+
+
+def aggregate_yaml_files(input_dir: str, output_file: str = "multi_tf_static.yaml") -> bool:
+    """Aggregate all YAML files in the specified directory (wrapper for backward compatibility)
+
+    Args:
+        input_dir: Path to input directory
+        output_file: Output filename
+
+    Returns:
+        True on success, False on failure
+    """
+    aggregator = YamlAggregator(input_dir, output_file)
+    return aggregator.aggregate()
+
+def setup_logging(verbose: bool = False) -> None:
+    """Configure logging settings"""
+    level = logging.DEBUG if verbose else logging.WARNING
+    logging.basicConfig(
+        level=level,
+        format='%(levelname)s: %(message)s'
+    )
+
+
+def main() -> None:
+    """Main function"""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="aggregate_calibration_files",
+        description="Aggregate calibration YAML files for ROS static transforms"
+    )
+    parser.add_argument(
+        "input_dir",
+        nargs="?",
+        default="data",
+        help="Input directory containing YAML files (default: data)"
+    )
+    parser.add_argument(
+        "output_file",
+        nargs="?",
+        default="multi_tf_static.yaml",
+        help="Output file path (default: multi_tf_static.yaml in current directory)"
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose output"
+    )
+    parser.add_argument(
+        "--no-warnings",
+        action="store_true",
+        help="Suppress duplicate key warnings"
+    )
+
+    args = parser.parse_args()
+
+    setup_logging(args.verbose)
+
+    # Suppress duplicate warnings if requested
+    if args.no_warnings:
+        # Set to ERROR to suppress WARNING messages
+        logging.getLogger().setLevel(logging.ERROR)
+
+    success = aggregate_yaml_files(args.input_dir, args.output_file)
+    sys.exit(0 if success else 1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/backup_drs_config.py
+++ b/scripts/backup_drs_config.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+DRS configuration file backup script
+
+Retrieves files from specified folders on ecu0 and ecu1, then saves them.
+"""
+
+import argparse
+import logging
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+import shutil
+
+
+class DRSBackup:
+    """DRS configuration file backup class"""
+
+    # ECU information
+    ECU0_HOST = "nvidia@192.168.20.1"
+    ECU1_HOST = "nvidia@192.168.20.2"
+
+    # Backup target directories
+    BACKUP_DIRS = [
+        "/opt/drs/config",
+        "/opt/drs/service",
+        "/opt/drs/install"
+    ]
+
+    DEFAULT_KEYWORD = "drs_backup"
+
+    def __init__(self, keyword: str = DEFAULT_KEYWORD, user: str = None, use_scp: bool = False):
+        """
+        Initialize backup instance
+
+        Args:
+            keyword: Keyword for backup folder name
+            user: SSH username (None means current user)
+            use_scp: Use scp if True, rsync if False
+        """
+        self.keyword = keyword
+        self.user = user
+        self.use_scp = use_scp
+        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.backup_dir = Path(f"{self.timestamp}_{self.keyword}")
+
+    def setup_logging(self, verbose: bool = False) -> None:
+        """Configure logging"""
+        level = logging.DEBUG if verbose else logging.INFO
+        logging.basicConfig(
+            level=level,
+            format='%(levelname)s: %(message)s'
+        )
+
+    def build_remote_path(self, host: str, remote_path: str) -> str:
+        """
+        Build remote path string
+
+        Args:
+            host: Remote host address
+            remote_path: Remote path
+
+        Returns:
+            Remote path string
+        """
+        if self.user:
+            return f"{self.user}@{host}:{remote_path}"
+        return f"{host}:{remote_path}"
+
+    def backup_from_host(self, host: str, hostname: str) -> bool:
+        """
+        Backup files from specified host
+
+        Args:
+            host: Remote host IP address
+            hostname: Hostname (ecu0/ecu1)
+
+        Returns:
+            True on success, False on failure
+        """
+        host_backup_dir = self.backup_dir / hostname
+
+        logging.info(f"Backing up from {hostname} ({host})...")
+
+        # Create directory for this host
+        host_backup_dir.mkdir(parents=True, exist_ok=True)
+
+        success = True
+        for remote_dir in self.BACKUP_DIRS:
+            logging.info(f"  Copying {remote_dir}...")
+
+            # Create local target directory (preserve remote path structure)
+            local_dir_name = Path(remote_dir).name
+            local_target_dir = host_backup_dir / local_dir_name
+
+            if self.use_scp:
+                # Use scp
+                result = self._copy_with_scp(host, remote_dir, local_target_dir)
+            else:
+                # Use rsync (default)
+                result = self._copy_with_rsync(host, remote_dir, local_target_dir)
+
+            if not result:
+                logging.error(f"  Failed to copy {remote_dir}")
+                success = False
+            else:
+                logging.info(f"  Successfully copied {remote_dir}")
+
+        return success
+
+    def _copy_with_rsync(self, host: str, remote_path: str, local_target: Path) -> bool:
+        """
+        Copy files using rsync
+
+        Args:
+            host: Remote host address
+            remote_path: Remote path
+            local_target: Local destination path
+
+        Returns:
+            True on success
+        """
+        remote = self.build_remote_path(host, remote_path)
+
+        # Build rsync command
+        # -a: Archive mode (preserve permissions, timestamps, etc.)
+        # -v: Verbose output
+        # -z: Compress during transfer
+        # --delete: Sync deleted files
+        cmd = [
+            "rsync",
+            "-avz",
+            "--delete",
+            f"{remote}/",
+            str(local_target)
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            if result.stdout:
+                logging.debug(result.stdout)
+            return True
+        except subprocess.CalledProcessError as e:
+            logging.error(f"rsync failed: {e.stderr}")
+            return False
+        except FileNotFoundError:
+            logging.error("rsync command not found. Please install rsync.")
+            return False
+
+    def _copy_with_scp(self, host: str, remote_path: str, local_target: Path) -> bool:
+        """
+        Copy files using scp
+
+        Args:
+            host: Remote host address
+            remote_path: Remote path
+            local_target: Local destination path
+
+        Returns:
+            True on success
+        """
+        remote = self.build_remote_path(host, remote_path)
+
+        # Build scp command
+        # -r: Recursive copy
+        # -p: Preserve timestamps and permissions
+        cmd = [
+            "scp",
+            "-r",
+            "-p",
+            f"{remote}",
+            str(local_target.parent)
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=True
+            )
+            if result.stdout:
+                logging.debug(result.stdout)
+
+            # scp copies to parent directory, so adjust the name
+            copied_dir = local_target.parent / Path(remote_path).name
+            if copied_dir.exists() and copied_dir != local_target:
+                if local_target.exists():
+                    shutil.rmtree(local_target)
+                copied_dir.rename(local_target)
+
+            return True
+        except subprocess.CalledProcessError as e:
+            logging.error(f"scp failed: {e.stderr}")
+            return False
+        except FileNotFoundError:
+            logging.error("scp command not found. Please install openssh-client.")
+            return False
+
+    def run(self, ecu_list: list = None) -> bool:
+        """
+        Execute backup process
+
+        Args:
+            ecu_list: List of ECUs to backup (["ecu0"], ["ecu1"], or ["ecu0", "ecu1"]).
+                     If None, backup both ECUs.
+
+        Returns:
+            True on success
+        """
+        logging.info(f"Starting DRS backup to {self.backup_dir}")
+
+        # Create backup directory
+        self.backup_dir.mkdir(parents=True, exist_ok=True)
+
+        # Determine which ECUs to backup
+        if ecu_list is None:
+            ecu_list = ["ecu0", "ecu1"]
+
+        # Backup from specified ECUs
+        success = True
+        if "ecu0" in ecu_list:
+            success &= self.backup_from_host(self.ECU0_HOST, "ecu0")
+        if "ecu1" in ecu_list:
+            success &= self.backup_from_host(self.ECU1_HOST, "ecu1")
+
+        if not success:
+            logging.error("Some backup operations failed")
+            return False
+
+        logging.info("Backup completed successfully")
+        return True
+
+
+def main():
+    """Main function"""
+    parser = argparse.ArgumentParser(
+        prog="backup_drs_config",
+        description="Backup DRS configuration files from ecu0 and ecu1"
+    )
+    parser.add_argument(
+        "-k", "--keyword",
+        default=DRSBackup.DEFAULT_KEYWORD,
+        help=f"Keyword for backup folder name (default: {DRSBackup.DEFAULT_KEYWORD})"
+    )
+    parser.add_argument(
+        "-u", "--user",
+        default=None,
+        help="SSH username (default: current user)"
+    )
+    parser.add_argument(
+        "--scp",
+        action="store_true",
+        help="Use scp instead of rsync (default: rsync)"
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Enable verbose output"
+    )
+    parser.add_argument(
+        "--ecu",
+        choices=["ecu0", "ecu1", "both"],
+        default="both",
+        help="ECU to backup: ecu0, ecu1, or both (default: both)"
+    )
+
+    args = parser.parse_args()
+
+    backup = DRSBackup(
+        keyword=args.keyword,
+        user=args.user,
+        use_scp=args.scp
+    )
+    backup.setup_logging(verbose=args.verbose)
+
+    # Determine ECU list based on argument
+    if args.ecu == "both":
+        ecu_list = ["ecu0", "ecu1"]
+    else:
+        ecu_list = [args.ecu]
+
+    success = backup.run(ecu_list=ecu_list)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Restore the two standalone utility scripts that existed at tag v0.1.9 and were removed in #166 (e5d9e45) as unused:

- `scripts/aggregate_calibration_files.py`: merges calibration YAML files into a single `multi_tf_static.yaml`.
- `scripts/backup_drs_config.py`: backs up `/opt/drs/{config,service,install}` from ecu0/ecu1 over rsync/scp.

Both files are restored verbatim from tag v0.1.9 with no modifications.

## How to verify

- `git diff v0.1.9 -- scripts/aggregate_calibration_files.py scripts/backup_drs_config.py` shows no differences.
- `python3 -m py_compile` passes for both scripts.
- `pre-commit run --all-files` passes.

## Improvements

- Brings back the calibration aggregation and DRS config backup utilities for local operational use.

## Limitations

- The scripts are not referenced by any launch file, Ansible playbook, CI workflow, or documentation; they are intended for manual use only.